### PR TITLE
Refactor: ゲームロジックをBoardクラスに分離し、bitsetによる盤面管理を導入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,10 @@ SRC_DIR            = src/
 OBJ_DIR            = .obj/
 SRC_FILES          = main.cpp \
                      Gomoku.cpp \
-					 MenuScene.cpp \
-					 GameScene.cpp \
-					 ResultScene.cpp
+										 MenuScene.cpp \
+										 GameScene.cpp \
+										 ResultScene.cpp \
+										 Board.cpp
 IFLAGS            += -Iinclude
 SRCS               = $(addprefix $(SRC_DIR), $(SRC_FILES))
 OBJS               = $(addprefix $(OBJ_DIR), $(SRC_FILES:.cpp=.o))

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -1,0 +1,29 @@
+#ifndef BOARD_HPP
+#define BOARD_HPP
+
+#include <bitset>
+#include <vector>
+
+const unsigned int BOARD_SIZE = 19;
+const int BOARD_WIDTH = 20;  // 19 + 1 sentinel
+const int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
+
+enum class Player { NONE, BLACK, WHITE };
+
+class Board {
+ public:
+  Board();
+
+  bool makeMove(int x, int y);
+  Player getStoneAt(int x, int y) const;
+  Player getCurrentTurn() const;
+  bool checkWin(int x, int y);
+
+ private:
+  std::bitset<MAX_CELLS> _blackStones;
+  std::bitset<MAX_CELLS> _whiteStones;
+  Player _currentTurn;
+  int getIndex(int x, int y) const;
+};
+
+#endif

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -1,10 +1,10 @@
 #ifndef GAMESCENE_HPP
 #define GAMESCENE_HPP
 
+#include <Board.hpp>
 #include <Scene.hpp>
 #include <functional>
 
-const unsigned int BOARD_SIZE = 19;
 const unsigned int CELL_SIZE = 40;
 const float OFFSET = 20.0f;
 const unsigned int WINDOW_WIDTH = BOARD_SIZE * CELL_SIZE;
@@ -26,12 +26,9 @@ class GameScene : public Scene {
   const unsigned int _cellSize = CELL_SIZE;
   sf::Vector2f _boardOffset;
 
-  std::bitset<BOARD_SIZE*(BOARD_SIZE + 1)> _blackStones;
-  std::bitset<BOARD_SIZE*(BOARD_SIZE + 1)> _whiteStones;
+  Board _board;
   void handleClick(int x, int y);
   std::function<void()> _onGameOver;
-
-  bool _isBlackTurn = false;  // 仮
 };
 
 #endif

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,0 +1,52 @@
+#include <Board.hpp>
+
+Board::Board() : _currentTurn(Player::BLACK) {
+  _blackStones.reset();
+  _whiteStones.reset();
+}
+
+bool Board::makeMove(int x, int y) {
+  if (x < 0 || x >= BOARD_SIZE || y < 0 || y >= BOARD_SIZE)
+    return false;
+
+  int index = getIndex(x, y);
+
+  // Check if the cell is already occupied
+  if (_blackStones.test(index) || _whiteStones.test(index)) {
+    return false;
+  }
+
+  // Place the stone
+  if (_currentTurn == Player::BLACK) {
+    _blackStones.set(index);
+    // TODO: Implement checkWin(x, y) and forbidden move checks
+  } else {
+    _whiteStones.set(index);
+  }
+
+  // Change turn
+  _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
+  return true;
+}
+
+Player Board::getStoneAt(int x, int y) const {
+  int index = getIndex(x, y);
+  if (_blackStones.test(index))
+    return Player::BLACK;
+  if (_whiteStones.test(index))
+    return Player::WHITE;
+  return Player::NONE;
+}
+
+Player Board::getCurrentTurn() const {
+  return _currentTurn;
+}
+
+bool Board::checkWin(int x, int y) {
+  // TODO: Implement fast win check using bit shifting
+  return false;
+}
+
+int Board::getIndex(int x, int y) const {
+  return y * BOARD_WIDTH + x;
+}

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -1,9 +1,6 @@
 #include <GameScene.hpp>
 
 GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize) : _font(font) {
-  this->_blackStones = 0;
-  this->_whiteStones = 0;
-
   onResize(initalSize);
 }
 
@@ -25,16 +22,15 @@ void GameScene::handleClick(int x, int y) {
 
   if (col >= 0 && col < static_cast<int>(_boardSize) && row >= 0 &&
       row < static_cast<int>(_boardSize)) {
-    unsigned int index = row * (_boardSize + 1) + col;
+    // makeMoveが成功（ルール上OK）なら、内部状態が更新される
+    if (_board.makeMove(col, row)) {
+      // TODO: SEを鳴らすなどの処理があればここに書く
 
-    if (!_blackStones.test(index) && !_whiteStones.test(index)) {
-      if (this->_isBlackTurn) {
-        _blackStones.set(index);
-      } else {
-        _whiteStones.set(index);
+      // 勝利判定
+      /* if (_board.checkWin(col, row)) {
+          if (_onGameOver) _onGameOver();
       }
-
-      _isBlackTurn = !_isBlackTurn;
+      */
     }
   }
 }
@@ -61,21 +57,16 @@ void GameScene::render(sf::RenderWindow& window) {
   sf::CircleShape stone(15.f);
   stone.setOrigin(sf::Vector2f(15.0f, 15.f));
 
-  const unsigned int rowStride = _boardSize + 1;
-
   for (unsigned int y = 0; y < _boardSize; ++y) {
     for (unsigned int x = 0; x < _boardSize; ++x) {
-      unsigned int index = y * rowStride + x;
+      Player p = _board.getStoneAt(x, y);
 
-      bool isBlack = _blackStones.test(index);
-      bool isWhite = _whiteStones.test(index);
-
-      if (isBlack || isWhite) {
+      if (p != Player::NONE) {
         float posX = _boardOffset.x + static_cast<float>(x * _cellSize);
         float posY = _boardOffset.y + static_cast<float>(y * _cellSize);
         stone.setPosition(sf::Vector2f(posX, posY));
 
-        stone.setFillColor(isBlack ? sf::Color::Black : sf::Color::White);
+        stone.setFillColor(p == Player::BLACK ? sf::Color::Black : sf::Color::White);
         window.draw(stone);
       }
     }


### PR DESCRIPTION
# 概要
`GameScene` クラスに含まれていたゲームロジック（石の配置、ターン管理、盤面データ）を、新しく作成した `Board` クラスに分離しました。 これにより、`GameScene` は描画と入力処理に集中し、`Board` は純粋なゲームルールを管理する「疎結合」な設計になりました。

## 変更点

- **Board クラスの作成 (`Board.hpp`, `Board.cpp`):**
    - `enum class Player` を導入し、状態管理（BLACK, WHITE, NONE）を型安全に
- **GameScene のリファクタリング:**
    - 直接 bitset を操作するコードを削除し、Board クラスのメソッドを使用するように変更
    - 描画ロジックを `Board::getStoneAt` を使用する形に修正

### 補足

- 勝敗判定 (`checkWin`) はメソッドの枠組みのみ作成しており、中身のビット演算ロジックは別ブランチで実装します

## テスト

- コンパイルができるか
- 変わりなくコマを置くことができるか
