### PR TITLE
Feat: ビット演算を用いた高速な勝利判定ロジックの実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports": "explicit" // organize imports on save
   },
+  "editor.tabSize": 4,
 
   // --- Prettier Settings for Other Files ---
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,12 @@ endif
 SRC_DIR            = src/
 OBJ_DIR            = .obj/
 SRC_FILES          = main.cpp \
-                     Gomoku.cpp \
-										 MenuScene.cpp \
-										 GameScene.cpp \
-										 ResultScene.cpp \
-										 Board.cpp
+					 Gomoku.cpp \
+					 MenuScene.cpp \
+					 GameScene.cpp \
+					 ResultScene.cpp \
+					 Board.cpp
+
 IFLAGS            += -Iinclude
 SRCS               = $(addprefix $(SRC_DIR), $(SRC_FILES))
 OBJS               = $(addprefix $(OBJ_DIR), $(SRC_FILES:.cpp=.o))

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -18,6 +18,7 @@ class Board {
   Player getStoneAt(int x, int y) const;
   Player getCurrentTurn() const;
   bool checkWin();
+  void changeTurn();
 
  private:
   std::bitset<MAX_CELLS> _blackStones;

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -17,7 +17,7 @@ class Board {
   bool makeMove(int x, int y);
   Player getStoneAt(int x, int y) const;
   Player getCurrentTurn() const;
-  bool checkWin(int x, int y);
+  bool checkWin();
 
  private:
   std::bitset<MAX_CELLS> _blackStones;

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -23,7 +23,13 @@ class Board {
   std::bitset<MAX_CELLS> _blackStones;
   std::bitset<MAX_CELLS> _whiteStones;
   Player _currentTurn;
-  int getIndex(int x, int y) const;
+  static constexpr int SHIFT_H = 1;                 // 横
+  static constexpr int SHIFT_V = BOARD_WIDTH;       // 縦 (20)
+  static constexpr int SHIFT_D1 = BOARD_WIDTH + 1;  // 右下 (21)
+  static constexpr int SHIFT_D2 = BOARD_WIDTH - 1;  // 左下 (19)
+
+  int _getIndex(int x, int y) const;
+  bool _hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amount) const;
 };
 
 #endif

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -9,19 +9,21 @@ bool Board::makeMove(int x, int y) {
   if (x < 0 || x >= BOARD_SIZE || y < 0 || y >= BOARD_SIZE)
     return false;
 
-  int index = getIndex(x, y);
+  int index = _getIndex(x, y);
 
-  // Check if the cell is already occupied
   if (_blackStones.test(index) || _whiteStones.test(index)) {
     return false;
   }
 
-  // Place the stone
   if (_currentTurn == Player::BLACK) {
     _blackStones.set(index);
-    // TODO: Implement checkWin(x, y) and forbidden move checks
   } else {
     _whiteStones.set(index);
+  }
+
+  if (checkWin(x, y)) {
+    // TODO: implement a proper win handling mechanism
+    printf("Player %s wins!\n", (_currentTurn == Player::BLACK) ? "Black" : "White");
   }
 
   // Change turn
@@ -30,7 +32,7 @@ bool Board::makeMove(int x, int y) {
 }
 
 Player Board::getStoneAt(int x, int y) const {
-  int index = getIndex(x, y);
+  int index = _getIndex(x, y);
   if (_blackStones.test(index))
     return Player::BLACK;
   if (_whiteStones.test(index))
@@ -42,11 +44,33 @@ Player Board::getCurrentTurn() const {
   return _currentTurn;
 }
 
+bool Board::_hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amount) const {
+  std::bitset<MAX_CELLS> temp = stones;
+
+  // 1回ずらしてANDをとる = 「2個並んでいる場所」が1になる
+  temp &= (temp >> shift_amount);
+  temp &= (temp >> shift_amount);  // 3連
+  temp &= (temp >> shift_amount);  // 4連
+  temp &= (temp >> shift_amount);  // 5連
+
+  return temp.any();
+}
+
 bool Board::checkWin(int x, int y) {
-  // TODO: Implement fast win check using bit shifting
+  const auto& stones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
+
+  if (_hasFiveInARow(stones, SHIFT_H))
+    return true;  // 横
+  if (_hasFiveInARow(stones, SHIFT_V))
+    return true;  // 縦
+  if (_hasFiveInARow(stones, SHIFT_D1))
+    return true;  // 右下
+  if (_hasFiveInARow(stones, SHIFT_D2))
+    return true;  // 左下
+
   return false;
 }
 
-int Board::getIndex(int x, int y) const {
+int Board::_getIndex(int x, int y) const {
   return y * BOARD_WIDTH + x;
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -51,7 +51,7 @@ bool Board::_hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amoun
   return temp.any();
 }
 
-bool Board::checkWin(int x, int y) {
+bool Board::checkWin() {
   const auto& stones = (_currentTurn == Player::WHITE) ? _blackStones : _whiteStones;
 
   if (_hasFiveInARow(stones, SHIFT_H))

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -5,6 +5,10 @@ Board::Board() : _currentTurn(Player::BLACK) {
   _whiteStones.reset();
 }
 
+void Board::changeTurn() {
+  _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
+}
+
 bool Board::makeMove(int x, int y) {
   if (x < 0 || x >= BOARD_SIZE || y < 0 || y >= BOARD_SIZE)
     return false;
@@ -21,8 +25,6 @@ bool Board::makeMove(int x, int y) {
     _whiteStones.set(index);
   }
 
-  // Change turn
-  _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
   return true;
 }
 
@@ -52,7 +54,7 @@ bool Board::_hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amoun
 }
 
 bool Board::checkWin() {
-  const auto& stones = (_currentTurn == Player::WHITE) ? _blackStones : _whiteStones;
+  const auto& stones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
 
   if (_hasFiveInARow(stones, SHIFT_H))
     return true;  // 横

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -21,11 +21,6 @@ bool Board::makeMove(int x, int y) {
     _whiteStones.set(index);
   }
 
-  if (checkWin(x, y)) {
-    // TODO: implement a proper win handling mechanism
-    printf("Player %s wins!\n", (_currentTurn == Player::BLACK) ? "Black" : "White");
-  }
-
   // Change turn
   _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
   return true;
@@ -57,7 +52,7 @@ bool Board::_hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amoun
 }
 
 bool Board::checkWin(int x, int y) {
-  const auto& stones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
+  const auto& stones = (_currentTurn == Player::WHITE) ? _blackStones : _whiteStones;
 
   if (_hasFiveInARow(stones, SHIFT_H))
     return true;  // 横

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -26,11 +26,10 @@ void GameScene::handleClick(int x, int y) {
     if (_board.makeMove(col, row)) {
       // TODO: SEを鳴らすなどの処理があればここに書く
 
-      // 勝利判定
-      /* if (_board.checkWin(col, row)) {
-          if (_onGameOver) _onGameOver();
+      if (_board.checkWin(col, row)) {
+        if (_onGameOver)
+          _onGameOver();
       }
-      */
     }
   }
 }

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -26,7 +26,7 @@ void GameScene::handleClick(int x, int y) {
     if (_board.makeMove(col, row)) {
       // TODO: SEを鳴らすなどの処理があればここに書く
 
-      if (_board.checkWin(col, row)) {
+      if (_board.checkWin()) {
         if (_onGameOver)
           _onGameOver();
       }

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -30,6 +30,8 @@ void GameScene::handleClick(int x, int y) {
         if (_onGameOver)
           _onGameOver();
       }
+
+      _board.changeTurn();
     }
   }
 }

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -27,6 +27,8 @@ void GameScene::handleClick(int x, int y) {
       // TODO: SEを鳴らすなどの処理があればここに書く
 
       if (_board.checkWin()) {
+        // TODO: debug用
+        printf("Player %s wins!\n", _board.getCurrentTurn() == Player::BLACK ? "Black" : "White");
         if (_onGameOver)
           _onGameOver();
       }


### PR DESCRIPTION
# 概要
Board クラスに勝敗判定処理 (`checkWin`) を実装し、GameScene から呼び出せるようにしました。 判定ロジックには `std::bitset` のビットシフト演算を採用し、全盤面を一括で走査することで、ループ処理を排除した高速かつシンプルな実装を行いました。
また、ターン遷移の制御を Board クラスの自動処理から GameScene による明示的な制御へ変更しました。

## 変更点

- **勝利判定ロジックの実装 (`Board::checkWin`, `Board::_hasFiveInARow`):**
    - 指定した方向（横・縦・斜め2種）へビット列をシフトし、AND演算を繰り返すことで5連を検出。
    - 探索計算量は盤面サイズに依存せず、ビット演算数回で完了するため非常に高速。
- **定数の定義:**
    - シフト量 (`SHIFT_H, SHIFT_V, SHIFT_D1, SHIFT_D2`) を定義。番人(`BOARD_WIDTH = 20`)を考慮した値に設定。
- GameSceneの更新:
    - `handleClick` 内で `makeMove` 直後に `checkWin` をコールし、勝利時にリザルト画面へ遷移するコールバックを実行するように結合。
- **ターン管理の仕様変更:**
    - `Board::makeMove` 内での自動ターン交代を廃止
    - `Board::changeTurn` メソッドを新規追加し、GameScene 側で制御するように変更

## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト

- コンパイルできるか
- 5つ並んだ瞬間に正しくリザルト画面（現状はコールバック）へ遷移するか。
- その際CLIに勝利したチームが表示されるか
