### PR TITLE
メニュー画面とリザルト画面を変更

### DIFF
--- a/include/Enums.hpp
+++ b/include/Enums.hpp
@@ -1,0 +1,8 @@
+#ifndef ENUMS_HPP
+#define ENUMS_HPP
+
+enum class AILevel { Easy, Medium, Hard };
+
+enum class TurnOrder { PlayerFirst, AIFirst };
+
+#endif

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -4,6 +4,7 @@
 #include <Board.hpp>
 #include <Enums.hpp>
 #include <Scene.hpp>
+#include <Theme.hpp>
 #include <functional>
 
 const unsigned int CELL_SIZE = 40;

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -2,6 +2,7 @@
 #define GAMESCENE_HPP
 
 #include <Board.hpp>
+#include <Enums.hpp>
 #include <Scene.hpp>
 #include <functional>
 
@@ -19,12 +20,16 @@ class GameScene : public Scene {
   void onResize(const sf::Vector2u& windowSize);
 
   void setOnGameOver(std::function<void(const std::string& winner)> callback);
+  void setAILevel(AILevel& level);
+  void setTurnOrder(TurnOrder turnOrder);
 
  private:
   sf::Font& _font;
   const unsigned int _boardSize = BOARD_SIZE;
   const unsigned int _cellSize = CELL_SIZE;
   sf::Vector2f _boardOffset;
+  AILevel _aiLevel;
+  TurnOrder _turnOrder;
 
   Board _board;
   void handleClick(int x, int y);

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -18,7 +18,7 @@ class GameScene : public Scene {
   void render(sf::RenderWindow& window);
   void onResize(const sf::Vector2u& windowSize);
 
-  void setOnGameOver(std::function<void()> callback);
+  void setOnGameOver(std::function<void(const std::string& winner)> callback);
 
  private:
   sf::Font& _font;
@@ -28,7 +28,7 @@ class GameScene : public Scene {
 
   Board _board;
   void handleClick(int x, int y);
-  std::function<void()> _onGameOver;
+  std::function<void(const std::string& winner)> _onGameOver;
 };
 
 #endif

--- a/include/Gomoku.hpp
+++ b/include/Gomoku.hpp
@@ -32,6 +32,7 @@ class Gomoku {
   void initFont(const std::string font);
   EventList getEventList();
   void changeScene(Scene* nextScene);
+  void initOnGameOver(const std::string& winner);
 };
 
 #endif

--- a/include/MenuScene.hpp
+++ b/include/MenuScene.hpp
@@ -1,6 +1,7 @@
 #ifndef MENUSCENE_HPP
 #define MENUSCENE_HPP
 
+#include <Enums.hpp>
 #include <Scene.hpp>
 #include <functional>
 
@@ -13,10 +14,9 @@ class MenuScene : public Scene {
   void render(sf::RenderWindow& window);
   void onResize(const sf::Vector2u& windowSize);
 
-  void setOnStartGame(std::function<void()> callback);
+  void setOnStartGame(std::function<void(TurnOrder turnOrder, AILevel& level)> callback);
 
  private:
-  enum Level { Easy, Medium, Hard };
   sf::Font& _font;
   sf::Text _titleText;
   sf::RectangleShape _startButton;
@@ -33,9 +33,9 @@ class MenuScene : public Scene {
   sf::Text _firstText;
   sf::Text _secondText;
   sf::Text _startButtonText;
-  bool _isFirst = true;
-  Level _level = Level::Medium;
-  std::function<void()> _onStartGame;
+  TurnOrder _turnOrder = TurnOrder::PlayerFirst;
+  AILevel _aiLevel = AILevel::Medium;
+  std::function<void(TurnOrder turnOrder, AILevel& level)> _onStartGame;
 };
 
 #endif

--- a/include/MenuScene.hpp
+++ b/include/MenuScene.hpp
@@ -16,10 +16,25 @@ class MenuScene : public Scene {
   void setOnStartGame(std::function<void()> callback);
 
  private:
+  enum Level { Easy, Medium, Hard };
   sf::Font& _font;
   sf::Text _titleText;
   sf::RectangleShape _startButton;
+  sf::Text _orderText;
+  sf::RectangleShape _firstButton;
+  sf::RectangleShape _secondButton;
+  sf::RectangleShape _easyButton;
+  sf::RectangleShape _mediumButton;
+  sf::RectangleShape _hardButton;
+  sf::Text _levelText;
+  sf::Text _mediumText;
+  sf::Text _easyText;
+  sf::Text _hardText;
+  sf::Text _firstText;
+  sf::Text _secondText;
   sf::Text _startButtonText;
+  bool _isFirst = true;
+  Level _level = Level::Medium;
   std::function<void()> _onStartGame;
 };
 

--- a/include/MenuScene.hpp
+++ b/include/MenuScene.hpp
@@ -3,6 +3,7 @@
 
 #include <Enums.hpp>
 #include <Scene.hpp>
+#include <Theme.hpp>
 #include <functional>
 
 class MenuScene : public Scene {

--- a/include/ResultScene.hpp
+++ b/include/ResultScene.hpp
@@ -12,12 +12,16 @@ class ResultScene : public Scene {
   void onResize(const sf::Vector2u& windowSize);
 
   void setBackground(const sf::Window& window);
+  void setWinner(const std::string& winner);
+
+  const sf::Color DarkGrey = sf::Color(100, 100, 100);
 
  private:
   sf::Font& _font;
   sf::Text _titleText;
   sf::Texture _backgroundTexture;
   std::unique_ptr<sf::Sprite> _backgroundSprite;
+  sf::Text _winnerText;
 };
 
 #endif

--- a/include/ResultScene.hpp
+++ b/include/ResultScene.hpp
@@ -2,6 +2,7 @@
 #define RESULTSCENE_HPP
 
 #include <Scene.hpp>
+#include <Theme.hpp>
 
 class ResultScene : public Scene {
  public:

--- a/include/ResultScene.hpp
+++ b/include/ResultScene.hpp
@@ -14,8 +14,7 @@ class ResultScene : public Scene {
 
   void setBackground(const sf::Window& window);
   void setWinner(const std::string& winner);
-
-  const sf::Color DarkGrey = sf::Color(100, 100, 100);
+  void setOnBack(std::function<void()> func);
 
  private:
   sf::Font& _font;
@@ -23,6 +22,9 @@ class ResultScene : public Scene {
   sf::Texture _backgroundTexture;
   std::unique_ptr<sf::Sprite> _backgroundSprite;
   sf::Text _winnerText;
+  sf::RectangleShape _backButton;
+  sf::Text _backButtonText;
+  std::function<void()> _onBack;
 };
 
 #endif

--- a/include/ResultScene.hpp
+++ b/include/ResultScene.hpp
@@ -11,9 +11,13 @@ class ResultScene : public Scene {
   void render(sf::RenderWindow& window);
   void onResize(const sf::Vector2u& windowSize);
 
+  void setBackground(const sf::Window& window);
+
  private:
   sf::Font& _font;
   sf::Text _titleText;
+  sf::Texture _backgroundTexture;
+  std::unique_ptr<sf::Sprite> _backgroundSprite;
 };
 
 #endif

--- a/include/Theme.hpp
+++ b/include/Theme.hpp
@@ -1,0 +1,28 @@
+#ifndef THEME_HPP
+#define THEME_HPP
+
+#include <SFML/Graphics.hpp>
+
+namespace Theme {
+
+namespace Color {
+const sf::Color Text = sf::Color::Black;
+const sf::Color Background = sf::Color(100, 100, 100);
+const sf::Color ButtonIdle = sf::Color(80, 80, 80);
+const sf::Color ButtonActive = sf::Color(180, 180, 180);
+const sf::Color Board = sf::Color(200, 160, 100);
+const sf::Color BoardDarkened = sf::Color(200 * 100 / 255, 160 * 100 / 255, 100 * 100 / 255);
+}  // namespace Color
+
+namespace FontSize {
+const unsigned int Title = 80;
+const unsigned int Header = 45;
+const unsigned int Button = 25;
+}  // namespace FontSize
+
+namespace Size {
+const sf::Vector2f Button = {250.f, 60.f};
+}
+}  // namespace Theme
+
+#endif

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -97,3 +97,11 @@ void GameScene::onResize(const sf::Vector2u& windowSize) {
 void GameScene::setOnGameOver(std::function<void(const std::string& winner)> callback) {
   this->_onGameOver = callback;
 }
+
+void GameScene::setAILevel(AILevel& level) {
+  this->_aiLevel = level;
+}
+
+void GameScene::setTurnOrder(TurnOrder turnOrder) {
+  this->_turnOrder = turnOrder;
+}

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -40,7 +40,7 @@ void GameScene::handleClick(int x, int y) {
 }
 
 void GameScene::render(sf::RenderWindow& window) {
-  window.clear(sf::Color(200, 160, 100));
+  window.clear(Theme::Color::Board);
 
   const float boardLength = static_cast<float>((_boardSize - 1) * _cellSize);
 

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -29,8 +29,9 @@ void GameScene::handleClick(int x, int y) {
       if (_board.checkWin()) {
         // TODO: debug用
         printf("Player %s wins!\n", _board.getCurrentTurn() == Player::BLACK ? "Black" : "White");
+        std::string winner = _board.getCurrentTurn() == Player::BLACK ? "Black" : "White";
         if (_onGameOver)
-          _onGameOver();
+          _onGameOver(winner);
       }
 
       _board.changeTurn();
@@ -93,6 +94,6 @@ void GameScene::onResize(const sf::Vector2u& windowSize) {
   _boardOffset.y = (h - boardPixelSize) / 2.f;
 }
 
-void GameScene::setOnGameOver(std::function<void()> callback) {
+void GameScene::setOnGameOver(std::function<void(const std::string& winner)> callback) {
   this->_onGameOver = callback;
 }

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -10,7 +10,10 @@ Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
   this->_currentScene = this->_menuScene.get();
 
   this->_menuScene->setOnStartGame([this]() { changeScene(this->_gameScene.get()); });
-  this->_gameScene->setOnGameOver([this]() { changeScene(this->_resultScene.get()); });
+  this->_gameScene->setOnGameOver([this]() {
+    this->_resultScene.get()->setBackground(this->_window);
+    changeScene(this->_resultScene.get());
+  });
 }
 
 void Gomoku::run() {

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -14,13 +14,19 @@ Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
     this->_gameScene.get()->setTurnOrder(turnOrder);
     changeScene(this->_gameScene.get());
   });
-  this->_gameScene->setOnGameOver([this](const std::string& winner) {
-    this->_window.clear();
-    this->_gameScene->render(this->_window);
-    this->_resultScene.get()->setBackground(this->_window);
-    this->_resultScene.get()->setWinner(winner);
-    changeScene(this->_resultScene.get());
+  this->_gameScene->setOnGameOver([this](const std::string& winner) { initOnGameOver(winner); });
+  this->_resultScene->setOnBack([this] {
+    changeScene(this->_menuScene.get());
+    this->_gameScene = std::make_unique<GameScene>(font, this->_window.getSize());
+    this->_gameScene->setOnGameOver([this](const std::string& winner) { initOnGameOver(winner); });
   });
+}
+void Gomoku::initOnGameOver(const std::string& winner) {
+  this->_window.clear();
+  this->_gameScene->render(this->_window);
+  this->_resultScene.get()->setBackground(this->_window);
+  this->_resultScene.get()->setWinner(winner);
+  changeScene(this->_resultScene.get());
 }
 
 void Gomoku::run() {

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -10,8 +10,11 @@ Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
   this->_currentScene = this->_menuScene.get();
 
   this->_menuScene->setOnStartGame([this]() { changeScene(this->_gameScene.get()); });
-  this->_gameScene->setOnGameOver([this]() {
+  this->_gameScene->setOnGameOver([this](const std::string& winner) {
+    this->_window.clear();
+    this->_gameScene->render(this->_window);
     this->_resultScene.get()->setBackground(this->_window);
+    this->_resultScene.get()->setWinner(winner);
     changeScene(this->_resultScene.get());
   });
 }

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -1,7 +1,8 @@
 #include <Gomoku.hpp>
 
-Gomoku::Gomoku() : _window(sf::VideoMode({1000, 1000}), "Gomoku"), font() {
+Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
   initFont("arial.ttf");
+  this->_window.setMinimumSize(sf::Vector2u(1080, 1000));
 
   this->_menuScene = std::make_unique<MenuScene>(font, this->_window.getSize());
   this->_gameScene = std::make_unique<GameScene>(font, this->_window.getSize());
@@ -16,6 +17,7 @@ void Gomoku::run() {
   while (this->_window.isOpen()) {
     EventList events = getEventList();
     this->_currentScene->handleEvents(events);
+    this->_currentScene->update(0.f);
     this->_window.clear();
     this->_currentScene->render(this->_window);
     this->_window.display();

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -9,7 +9,11 @@ Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
   this->_resultScene = std::make_unique<ResultScene>(font, this->_window.getSize());
   this->_currentScene = this->_menuScene.get();
 
-  this->_menuScene->setOnStartGame([this]() { changeScene(this->_gameScene.get()); });
+  this->_menuScene->setOnStartGame([this](TurnOrder turnOrder, AILevel& level) {
+    this->_gameScene.get()->setAILevel(level);
+    this->_gameScene.get()->setTurnOrder(turnOrder);
+    changeScene(this->_gameScene.get());
+  });
   this->_gameScene->setOnGameOver([this](const std::string& winner) {
     this->_window.clear();
     this->_gameScene->render(this->_window);

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -1,7 +1,16 @@
 #include <MenuScene.hpp>
 
 MenuScene::MenuScene(sf::Font& font, const sf::Vector2u& initalSize)
-    : _font(font), _titleText(font, "Gomoku"), _startButtonText(font, "START GAME") {
+    : _font(font),
+      _titleText(font, "Gomoku"),
+      _startButtonText(font, "START GAME"),
+      _orderText(font, "You can choose: first or second?"),
+      _firstText(font, "Go first"),
+      _secondText(font, "Go second"),
+      _easyText(font, "Easy"),
+      _mediumText(font, "Medium"),
+      _hardText(font, "Hard"),
+      _levelText(font, "You can select the level.") {
   this->_titleText.setCharacterSize(80);
   this->_titleText.setFillColor(sf::Color::Black);
   this->_titleText.setStyle(sf::Text::Bold);
@@ -11,6 +20,61 @@ MenuScene::MenuScene(sf::Font& font, const sf::Vector2u& initalSize)
   this->_startButton.setSize({250.f, 60.f});
   this->_startButton.setFillColor(sf::Color(100, 100, 100));
   this->_startButton.setOrigin(this->_startButton.getSize() / 2.f);
+
+  this->_orderText.setCharacterSize(25);
+  this->_orderText.setFillColor(sf::Color::Black);
+  this->_orderText.setStyle(sf::Text::Bold);
+  this->_orderText.setOrigin(_orderText.getLocalBounds().getCenter());
+
+  this->_firstText.setCharacterSize(25);
+  this->_firstText.setFillColor(sf::Color::Black);
+  this->_firstText.setStyle(sf::Text::Bold);
+  this->_firstText.setOrigin(_firstText.getLocalBounds().getCenter());
+
+  this->_secondText.setCharacterSize(25);
+  this->_secondText.setFillColor(sf::Color::Black);
+  this->_secondText.setStyle(sf::Text::Bold);
+  this->_secondText.setOrigin(_secondText.getLocalBounds().getCenter());
+
+  this->_firstButton.setSize({250.f, 60.f});
+  this->_firstButton.setFillColor(sf::Color(100, 100, 100));
+  this->_firstButton.setOrigin(this->_firstButton.getSize() / 2.f);
+
+  this->_secondButton.setSize({250.f, 60.f});
+  this->_secondButton.setFillColor(sf::Color(100, 100, 100));
+  this->_secondButton.setOrigin(this->_secondButton.getSize() / 2.f);
+
+  this->_levelText.setCharacterSize(25);
+  this->_levelText.setFillColor(sf::Color::Black);
+  this->_levelText.setStyle(sf::Text::Bold);
+  this->_levelText.setOrigin(_levelText.getLocalBounds().getCenter());
+
+  this->_easyButton.setSize({250.f, 60.f});
+  this->_easyButton.setFillColor(sf::Color(100, 100, 100));
+  this->_easyButton.setOrigin(this->_easyButton.getSize() / 2.f);
+
+  this->_easyText.setCharacterSize(25);
+  this->_easyText.setFillColor(sf::Color::Black);
+  this->_easyText.setStyle(sf::Text::Bold);
+  this->_easyText.setOrigin(_easyText.getLocalBounds().getCenter());
+
+  this->_mediumButton.setSize({250.f, 60.f});
+  this->_mediumButton.setFillColor(sf::Color(100, 100, 100));
+  this->_mediumButton.setOrigin(this->_mediumButton.getSize() / 2.f);
+
+  this->_mediumText.setCharacterSize(25);
+  this->_mediumText.setFillColor(sf::Color::Black);
+  this->_mediumText.setStyle(sf::Text::Bold);
+  this->_mediumText.setOrigin(_mediumText.getLocalBounds().getCenter());
+
+  this->_hardButton.setSize({250.f, 60.f});
+  this->_hardButton.setFillColor(sf::Color(100, 100, 100));
+  this->_hardButton.setOrigin(this->_hardButton.getSize() / 2.f);
+
+  this->_hardText.setCharacterSize(25);
+  this->_hardText.setFillColor(sf::Color::Black);
+  this->_hardText.setStyle(sf::Text::Bold);
+  this->_hardText.setOrigin(_hardText.getLocalBounds().getCenter());
 
   this->_startButtonText.setCharacterSize(30);
   this->_startButtonText.setFillColor(sf::Color::White);
@@ -30,19 +94,69 @@ void MenuScene::handleEvents(const EventList& events) {
           if (this->_onStartGame)
             this->_onStartGame();
         }
+
+        if (this->_firstButton.getGlobalBounds().contains(mousePos)) {
+          this->_isFirst = true;
+        } else if (this->_secondButton.getGlobalBounds().contains(mousePos)) {
+          this->_isFirst = false;
+        }
+
+        if (this->_easyButton.getGlobalBounds().contains(mousePos)) {
+          this->_level = Level::Easy;
+        } else if (this->_mediumButton.getGlobalBounds().contains(mousePos)) {
+          this->_level = Level::Medium;
+        } else if (this->_hardButton.getGlobalBounds().contains(mousePos)) {
+          this->_level = Level::Hard;
+        }
       }
     }
   }
 }
 
 void MenuScene::update(float dt) {
+  sf::Color selectedColor(180, 180, 180);
+  sf::Color idleColor(100, 100, 100);
+
+  if (this->_isFirst) {
+    this->_firstButton.setFillColor(selectedColor);
+    this->_secondButton.setFillColor(idleColor);
+  } else {
+    this->_firstButton.setFillColor(idleColor);
+    this->_secondButton.setFillColor(selectedColor);
+  }
+
+  if (this->_level == Level::Easy) {
+    this->_easyButton.setFillColor(selectedColor);
+    this->_mediumButton.setFillColor(idleColor);
+    this->_hardButton.setFillColor(idleColor);
+  } else if (this->_level == Level::Medium) {
+    this->_easyButton.setFillColor(idleColor);
+    this->_mediumButton.setFillColor(selectedColor);
+    this->_hardButton.setFillColor(idleColor);
+  } else if (this->_level == Level::Hard) {
+    this->_easyButton.setFillColor(idleColor);
+    this->_mediumButton.setFillColor(idleColor);
+    this->_hardButton.setFillColor(selectedColor);
+  }
 }
 
 void MenuScene::render(sf::RenderWindow& window) {
   window.clear(sf::Color(50, 50, 50));
   window.draw(this->_titleText);
+  window.draw(this->_orderText);
   window.draw(this->_startButton);
+  window.draw(this->_firstButton);
+  window.draw(this->_firstText);
+  window.draw(this->_secondButton);
+  window.draw(this->_secondText);
   window.draw(this->_startButtonText);
+  window.draw(this->_levelText);
+  window.draw(this->_easyButton);
+  window.draw(this->_easyText);
+  window.draw(this->_mediumButton);
+  window.draw(this->_mediumText);
+  window.draw(this->_hardButton);
+  window.draw(this->_hardText);
 }
 
 void MenuScene::onResize(const sf::Vector2u& windowSize) {
@@ -50,8 +164,23 @@ void MenuScene::onResize(const sf::Vector2u& windowSize) {
   float h = static_cast<float>(windowSize.y);
 
   this->_titleText.setPosition({w / 2.f, h * 0.3f});
-  this->_startButton.setPosition({w / 2.f, h * 0.6f});
+  sf::Vector2f titlePos = this->_titleText.getPosition();
+  this->_orderText.setPosition({titlePos.x, titlePos.y + 90.f});
+  this->_startButton.setPosition({w / 2.f, h * 0.8f});
+  this->_firstButton.setPosition(
+      {_orderText.getPosition().x * 0.7f, _orderText.getPosition().y + 50.f});
+  this->_secondButton.setPosition(
+      {_orderText.getPosition().x * 1.3f, _orderText.getPosition().y + 50.f});
   this->_startButtonText.setPosition(this->_startButton.getPosition());
+  this->_firstText.setPosition(this->_firstButton.getPosition());
+  this->_secondText.setPosition(this->_secondButton.getPosition());
+  this->_levelText.setPosition({w / 2.f, _secondButton.getPosition().y + 80});
+  this->_easyButton.setPosition({w / 4.f, _levelText.getPosition().y + 50});
+  this->_easyText.setPosition(_easyButton.getPosition());
+  this->_mediumButton.setPosition({w / 2.f, _levelText.getPosition().y + 50});
+  this->_mediumText.setPosition(_mediumButton.getPosition());
+  this->_hardButton.setPosition({(w / 4.f) * 3.f, _levelText.getPosition().y + 50});
+  this->_hardText.setPosition(_hardButton.getPosition());
 }
 
 void MenuScene::setOnStartGame(std::function<void()> callback) {

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -92,21 +92,21 @@ void MenuScene::handleEvents(const EventList& events) {
                               static_cast<float>(mousePtr->position.y));
         if (this->_startButton.getGlobalBounds().contains(mousePos)) {
           if (this->_onStartGame)
-            this->_onStartGame();
+            this->_onStartGame(this->_turnOrder, this->_aiLevel);
         }
 
         if (this->_firstButton.getGlobalBounds().contains(mousePos)) {
-          this->_isFirst = true;
+          this->_turnOrder = TurnOrder::PlayerFirst;
         } else if (this->_secondButton.getGlobalBounds().contains(mousePos)) {
-          this->_isFirst = false;
+          this->_turnOrder = TurnOrder::AIFirst;
         }
 
         if (this->_easyButton.getGlobalBounds().contains(mousePos)) {
-          this->_level = Level::Easy;
+          this->_aiLevel = AILevel::Easy;
         } else if (this->_mediumButton.getGlobalBounds().contains(mousePos)) {
-          this->_level = Level::Medium;
+          this->_aiLevel = AILevel::Medium;
         } else if (this->_hardButton.getGlobalBounds().contains(mousePos)) {
-          this->_level = Level::Hard;
+          this->_aiLevel = AILevel::Hard;
         }
       }
     }
@@ -117,7 +117,7 @@ void MenuScene::update(float dt) {
   sf::Color selectedColor(180, 180, 180);
   sf::Color idleColor(100, 100, 100);
 
-  if (this->_isFirst) {
+  if (this->_turnOrder == TurnOrder::PlayerFirst) {
     this->_firstButton.setFillColor(selectedColor);
     this->_secondButton.setFillColor(idleColor);
   } else {
@@ -125,15 +125,15 @@ void MenuScene::update(float dt) {
     this->_secondButton.setFillColor(selectedColor);
   }
 
-  if (this->_level == Level::Easy) {
+  if (this->_aiLevel == AILevel::Easy) {
     this->_easyButton.setFillColor(selectedColor);
     this->_mediumButton.setFillColor(idleColor);
     this->_hardButton.setFillColor(idleColor);
-  } else if (this->_level == Level::Medium) {
+  } else if (this->_aiLevel == AILevel::Medium) {
     this->_easyButton.setFillColor(idleColor);
     this->_mediumButton.setFillColor(selectedColor);
     this->_hardButton.setFillColor(idleColor);
-  } else if (this->_level == Level::Hard) {
+  } else if (this->_aiLevel == AILevel::Hard) {
     this->_easyButton.setFillColor(idleColor);
     this->_mediumButton.setFillColor(idleColor);
     this->_hardButton.setFillColor(selectedColor);
@@ -183,6 +183,6 @@ void MenuScene::onResize(const sf::Vector2u& windowSize) {
   this->_hardText.setPosition(_hardButton.getPosition());
 }
 
-void MenuScene::setOnStartGame(std::function<void()> callback) {
+void MenuScene::setOnStartGame(std::function<void(TurnOrder turnOrder, AILevel& level)> callback) {
   this->_onStartGame = callback;
 }

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -10,68 +10,68 @@ MenuScene::MenuScene(sf::Font& font, const sf::Vector2u& initalSize)
       _easyText(font, "Easy"),
       _mediumText(font, "Medium"),
       _hardText(font, "Hard"),
-      _levelText(font, "You can select the level.") {
-  this->_titleText.setCharacterSize(80);
-  this->_titleText.setFillColor(sf::Color::Black);
+      _levelText(font, "You can select the AI level.") {
+  this->_titleText.setCharacterSize(Theme::FontSize::Title);
+  this->_titleText.setFillColor(Theme::Color::Text);
   this->_titleText.setStyle(sf::Text::Bold);
   sf::FloatRect titleBounds = this->_titleText.getLocalBounds();
   this->_titleText.setOrigin(titleBounds.getCenter());
 
-  this->_startButton.setSize({250.f, 60.f});
-  this->_startButton.setFillColor(sf::Color(100, 100, 100));
+  this->_startButton.setSize(Theme::Size::Button);
+  this->_startButton.setFillColor(Theme::Color::ButtonIdle);
   this->_startButton.setOrigin(this->_startButton.getSize() / 2.f);
 
-  this->_orderText.setCharacterSize(25);
+  this->_orderText.setCharacterSize(Theme::FontSize::Button);
   this->_orderText.setFillColor(sf::Color::Black);
   this->_orderText.setStyle(sf::Text::Bold);
   this->_orderText.setOrigin(_orderText.getLocalBounds().getCenter());
 
-  this->_firstText.setCharacterSize(25);
+  this->_firstText.setCharacterSize(Theme::FontSize::Button);
   this->_firstText.setFillColor(sf::Color::Black);
   this->_firstText.setStyle(sf::Text::Bold);
   this->_firstText.setOrigin(_firstText.getLocalBounds().getCenter());
 
-  this->_secondText.setCharacterSize(25);
+  this->_secondText.setCharacterSize(Theme::FontSize::Button);
   this->_secondText.setFillColor(sf::Color::Black);
   this->_secondText.setStyle(sf::Text::Bold);
   this->_secondText.setOrigin(_secondText.getLocalBounds().getCenter());
 
-  this->_firstButton.setSize({250.f, 60.f});
-  this->_firstButton.setFillColor(sf::Color(100, 100, 100));
+  this->_firstButton.setSize(Theme::Size::Button);
+  this->_firstButton.setFillColor(Theme::Color::ButtonIdle);
   this->_firstButton.setOrigin(this->_firstButton.getSize() / 2.f);
 
-  this->_secondButton.setSize({250.f, 60.f});
-  this->_secondButton.setFillColor(sf::Color(100, 100, 100));
+  this->_secondButton.setSize(Theme::Size::Button);
+  this->_secondButton.setFillColor(Theme::Color::ButtonIdle);
   this->_secondButton.setOrigin(this->_secondButton.getSize() / 2.f);
 
-  this->_levelText.setCharacterSize(25);
+  this->_levelText.setCharacterSize(Theme::FontSize::Button);
   this->_levelText.setFillColor(sf::Color::Black);
   this->_levelText.setStyle(sf::Text::Bold);
   this->_levelText.setOrigin(_levelText.getLocalBounds().getCenter());
 
-  this->_easyButton.setSize({250.f, 60.f});
-  this->_easyButton.setFillColor(sf::Color(100, 100, 100));
+  this->_easyButton.setSize(Theme::Size::Button);
+  this->_easyButton.setFillColor(Theme::Color::ButtonIdle);
   this->_easyButton.setOrigin(this->_easyButton.getSize() / 2.f);
 
-  this->_easyText.setCharacterSize(25);
+  this->_easyText.setCharacterSize(Theme::FontSize::Button);
   this->_easyText.setFillColor(sf::Color::Black);
   this->_easyText.setStyle(sf::Text::Bold);
   this->_easyText.setOrigin(_easyText.getLocalBounds().getCenter());
 
-  this->_mediumButton.setSize({250.f, 60.f});
-  this->_mediumButton.setFillColor(sf::Color(100, 100, 100));
+  this->_mediumButton.setSize(Theme::Size::Button);
+  this->_mediumButton.setFillColor(Theme::Color::ButtonIdle);
   this->_mediumButton.setOrigin(this->_mediumButton.getSize() / 2.f);
 
-  this->_mediumText.setCharacterSize(25);
+  this->_mediumText.setCharacterSize(Theme::FontSize::Button);
   this->_mediumText.setFillColor(sf::Color::Black);
   this->_mediumText.setStyle(sf::Text::Bold);
   this->_mediumText.setOrigin(_mediumText.getLocalBounds().getCenter());
 
-  this->_hardButton.setSize({250.f, 60.f});
-  this->_hardButton.setFillColor(sf::Color(100, 100, 100));
+  this->_hardButton.setSize(Theme::Size::Button);
+  this->_hardButton.setFillColor(Theme::Color::ButtonIdle);
   this->_hardButton.setOrigin(this->_hardButton.getSize() / 2.f);
 
-  this->_hardText.setCharacterSize(25);
+  this->_hardText.setCharacterSize(Theme::FontSize::Button);
   this->_hardText.setFillColor(sf::Color::Black);
   this->_hardText.setStyle(sf::Text::Bold);
   this->_hardText.setOrigin(_hardText.getLocalBounds().getCenter());
@@ -114,29 +114,26 @@ void MenuScene::handleEvents(const EventList& events) {
 }
 
 void MenuScene::update(float dt) {
-  sf::Color selectedColor(180, 180, 180);
-  sf::Color idleColor(100, 100, 100);
-
   if (this->_turnOrder == TurnOrder::PlayerFirst) {
-    this->_firstButton.setFillColor(selectedColor);
-    this->_secondButton.setFillColor(idleColor);
+    this->_firstButton.setFillColor(Theme::Color::ButtonActive);
+    this->_secondButton.setFillColor(Theme::Color::ButtonIdle);
   } else {
-    this->_firstButton.setFillColor(idleColor);
-    this->_secondButton.setFillColor(selectedColor);
+    this->_firstButton.setFillColor(Theme::Color::ButtonIdle);
+    this->_secondButton.setFillColor(Theme::Color::ButtonActive);
   }
 
   if (this->_aiLevel == AILevel::Easy) {
-    this->_easyButton.setFillColor(selectedColor);
-    this->_mediumButton.setFillColor(idleColor);
-    this->_hardButton.setFillColor(idleColor);
+    this->_easyButton.setFillColor(Theme::Color::ButtonActive);
+    this->_mediumButton.setFillColor(Theme::Color::ButtonIdle);
+    this->_hardButton.setFillColor(Theme::Color::ButtonIdle);
   } else if (this->_aiLevel == AILevel::Medium) {
-    this->_easyButton.setFillColor(idleColor);
-    this->_mediumButton.setFillColor(selectedColor);
-    this->_hardButton.setFillColor(idleColor);
+    this->_easyButton.setFillColor(Theme::Color::ButtonIdle);
+    this->_mediumButton.setFillColor(Theme::Color::ButtonActive);
+    this->_hardButton.setFillColor(Theme::Color::ButtonIdle);
   } else if (this->_aiLevel == AILevel::Hard) {
-    this->_easyButton.setFillColor(idleColor);
-    this->_mediumButton.setFillColor(idleColor);
-    this->_hardButton.setFillColor(selectedColor);
+    this->_easyButton.setFillColor(Theme::Color::ButtonIdle);
+    this->_mediumButton.setFillColor(Theme::Color::ButtonIdle);
+    this->_hardButton.setFillColor(Theme::Color::ButtonActive);
   }
 }
 

--- a/src/ResultScene.cpp
+++ b/src/ResultScene.cpp
@@ -1,23 +1,46 @@
 #include <ResultScene.hpp>
 
 ResultScene::ResultScene(sf::Font& font, const sf::Vector2u& initalSize)
-    : _font(font), _titleText(font, "Result"), _winnerText(font, "") {
+    : _font(font),
+      _titleText(font, "Result"),
+      _winnerText(font, ""),
+      _backButtonText(font, "Back to Menu") {
   this->_titleText.setCharacterSize(Theme::FontSize::Title);
-  this->_titleText.setFillColor(Theme::Color::Text);
+  this->_titleText.setFillColor(sf::Color::White);
   this->_titleText.setStyle(sf::Text::Bold);
   sf::FloatRect titleBounds = this->_titleText.getLocalBounds();
   this->_titleText.setOrigin(titleBounds.getCenter());
 
   this->_winnerText.setCharacterSize(Theme::FontSize::Header);
-  this->_winnerText.setFillColor(sf::Color::Black);
+  this->_winnerText.setFillColor(sf::Color::White);
   this->_winnerText.setStyle(sf::Text::Bold);
   this->_winnerText.setOrigin(_winnerText.getLocalBounds().getCenter());
+
+  this->_backButtonText.setCharacterSize(Theme::FontSize::Button);
+  this->_backButtonText.setFillColor(sf::Color::Black);
+  this->_backButtonText.setStyle(sf::Text::Bold);
+  this->_backButtonText.setOrigin(_backButtonText.getLocalBounds().getCenter());
+
+  this->_backButton.setSize(Theme::Size::Button);
+  this->_backButton.setFillColor(Theme::Color::ButtonActive);
+  this->_backButton.setOrigin(this->_backButton.getSize() / 2.f);
 
   onResize(initalSize);
 }
 
 void ResultScene::handleEvents(const EventList& events) {
   for (const auto e : events) {
+    if (const auto* mousePtr = e->getIf<sf::Event::MouseButtonPressed>()) {
+      if (mousePtr->button == sf::Mouse::Button::Left) {
+        sf::Vector2f mousePos(static_cast<float>(mousePtr->position.x),
+                              static_cast<float>(mousePtr->position.y));
+        if (this->_backButton.getGlobalBounds().contains(mousePos)) {
+          if (this->_onBack) {
+            this->_onBack();
+          }
+        }
+      }
+    }
   }
 }
 
@@ -32,6 +55,8 @@ void ResultScene::render(sf::RenderWindow& window) {
   }
   window.draw(_titleText);
   window.draw(_winnerText);
+  window.draw(_backButton);
+  window.draw(_backButtonText);
 }
 
 void ResultScene::onResize(const sf::Vector2u& windowSize) {
@@ -57,6 +82,8 @@ void ResultScene::onResize(const sf::Vector2u& windowSize) {
       this->_backgroundSprite->setPosition({offsetX, offsetY});
     }
   }
+  this->_backButton.setPosition({w / 2.f, h * 0.95f});
+  this->_backButtonText.setPosition(_backButton.getPosition());
 }
 
 void ResultScene::setBackground(const sf::Window& window) {
@@ -65,11 +92,15 @@ void ResultScene::setBackground(const sf::Window& window) {
 
     _backgroundSprite = std::make_unique<sf::Sprite>(_backgroundTexture);
 
-    _backgroundSprite->setColor(DarkGrey);
+    _backgroundSprite->setColor(Theme::Color::Background);
   }
 }
 
 void ResultScene::setWinner(const std::string& winner) {
   this->_winnerText.setString("Player " + winner + " wins!");
   this->_winnerText.setOrigin(_winnerText.getLocalBounds().getCenter());
+}
+
+void ResultScene::setOnBack(std::function<void()> func) {
+  this->_onBack = func;
 }

--- a/src/ResultScene.cpp
+++ b/src/ResultScene.cpp
@@ -2,13 +2,13 @@
 
 ResultScene::ResultScene(sf::Font& font, const sf::Vector2u& initalSize)
     : _font(font), _titleText(font, "Result"), _winnerText(font, "") {
-  this->_titleText.setCharacterSize(80);
-  this->_titleText.setFillColor(sf::Color::Black);
+  this->_titleText.setCharacterSize(Theme::FontSize::Title);
+  this->_titleText.setFillColor(Theme::Color::Text);
   this->_titleText.setStyle(sf::Text::Bold);
   sf::FloatRect titleBounds = this->_titleText.getLocalBounds();
   this->_titleText.setOrigin(titleBounds.getCenter());
 
-  this->_winnerText.setCharacterSize(45);
+  this->_winnerText.setCharacterSize(Theme::FontSize::Header);
   this->_winnerText.setFillColor(sf::Color::Black);
   this->_winnerText.setStyle(sf::Text::Bold);
   this->_winnerText.setOrigin(_winnerText.getLocalBounds().getCenter());
@@ -25,7 +25,7 @@ void ResultScene::update(float dt) {
 }
 
 void ResultScene::render(sf::RenderWindow& window) {
-  window.clear(sf::Color(200 * 100 / 255, 160 * 100 / 255, 100 * 100 / 255));
+  window.clear(Theme::Color::BoardDarkened);
 
   if (_backgroundSprite) {
     window.draw(*_backgroundSprite);

--- a/src/ResultScene.cpp
+++ b/src/ResultScene.cpp
@@ -20,8 +20,10 @@ void ResultScene::update(float dt) {
 }
 
 void ResultScene::render(sf::RenderWindow& window) {
-  window.clear(sf::Color(50, 50, 50));
-  window.draw(this->_titleText);
+  if (_backgroundSprite) {
+    window.draw(*_backgroundSprite);
+  }
+  window.draw(_titleText);
 }
 
 void ResultScene::onResize(const sf::Vector2u& windowSize) {
@@ -29,4 +31,12 @@ void ResultScene::onResize(const sf::Vector2u& windowSize) {
   float h = static_cast<float>(windowSize.y);
 
   this->_titleText.setPosition({w / 2.f, h * 0.3f});
+}
+
+void ResultScene::setBackground(const sf::Window& window) {
+  _backgroundTexture.update(window);
+
+  _backgroundSprite = std::make_unique<sf::Sprite>(_backgroundTexture);
+
+  _backgroundSprite->setColor(sf::Color(100, 100, 100));
 }

--- a/src/ResultScene.cpp
+++ b/src/ResultScene.cpp
@@ -1,12 +1,17 @@
 #include <ResultScene.hpp>
 
 ResultScene::ResultScene(sf::Font& font, const sf::Vector2u& initalSize)
-    : _font(font), _titleText(font, "Result") {
+    : _font(font), _titleText(font, "Result"), _winnerText(font, "") {
   this->_titleText.setCharacterSize(80);
   this->_titleText.setFillColor(sf::Color::Black);
   this->_titleText.setStyle(sf::Text::Bold);
   sf::FloatRect titleBounds = this->_titleText.getLocalBounds();
   this->_titleText.setOrigin(titleBounds.getCenter());
+
+  this->_winnerText.setCharacterSize(45);
+  this->_winnerText.setFillColor(sf::Color::Black);
+  this->_winnerText.setStyle(sf::Text::Bold);
+  this->_winnerText.setOrigin(_winnerText.getLocalBounds().getCenter());
 
   onResize(initalSize);
 }
@@ -20,10 +25,13 @@ void ResultScene::update(float dt) {
 }
 
 void ResultScene::render(sf::RenderWindow& window) {
+  window.clear(sf::Color(200 * 100 / 255, 160 * 100 / 255, 100 * 100 / 255));
+
   if (_backgroundSprite) {
     window.draw(*_backgroundSprite);
   }
   window.draw(_titleText);
+  window.draw(_winnerText);
 }
 
 void ResultScene::onResize(const sf::Vector2u& windowSize) {
@@ -31,12 +39,37 @@ void ResultScene::onResize(const sf::Vector2u& windowSize) {
   float h = static_cast<float>(windowSize.y);
 
   this->_titleText.setPosition({w / 2.f, h * 0.3f});
+  this->_winnerText.setPosition({w / 2.f, h * 0.4f});
+  if (this->_backgroundSprite) {
+    this->_backgroundSprite->setOrigin({0.f, 0.f});
+    this->_backgroundSprite->setPosition({0.f, 0.f});
+
+    sf::FloatRect textureRect = this->_backgroundSprite->getLocalBounds();
+    if (textureRect.size.x > 0 && textureRect.size.y > 0) {
+      float scaleX = w / textureRect.size.x;
+      float scaleY = h / textureRect.size.y;
+
+      float scale = std::min(scaleX, scaleY);
+      this->_backgroundSprite->setScale({scale, scale});
+
+      float offsetX = (w - (textureRect.size.x * scale)) / 2.f;
+      float offsetY = (h - (textureRect.size.y * scale)) / 2.f;
+      this->_backgroundSprite->setPosition({offsetX, offsetY});
+    }
+  }
 }
 
 void ResultScene::setBackground(const sf::Window& window) {
-  _backgroundTexture.update(window);
+  if (this->_backgroundTexture.resize(window.getSize())) {
+    _backgroundTexture.update(window);
 
-  _backgroundSprite = std::make_unique<sf::Sprite>(_backgroundTexture);
+    _backgroundSprite = std::make_unique<sf::Sprite>(_backgroundTexture);
 
-  _backgroundSprite->setColor(sf::Color(100, 100, 100));
+    _backgroundSprite->setColor(DarkGrey);
+  }
+}
+
+void ResultScene::setWinner(const std::string& winner) {
+  this->_winnerText.setString("Player " + winner + " wins!");
+  this->_winnerText.setOrigin(_winnerText.getLocalBounds().getCenter());
 }


### PR DESCRIPTION
# 概要
メニュー画面とリザルト画面の実装を進めました。
ゲームの処理とは切り離してるのでゲームの処理には影響はないです。

## 変更点

-  メニュー画面で先攻後攻の選択
- メニュー画面でAIのレベルの選択
- リザルト画面の背景に終了時の盤面の表示
- リザルト画面に勝者がどちらかの表示

## 影響範囲

主にメニュー画面、リザルト画面です。
GameSceneにも該当のメンバ変数とセッター関数だけ追加しています。

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- ビルドして今まで通りプレイできること
- 終了時に盤面、勝者がリザルト画面に表示されること

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #16 
