### PR TITLE
feat: Captures というルールを追加しました

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
   "cSpell.words": [
     "Abstra",
     "autopep",
+    "Capturable",
     "celerybeat",
     "codz",
     "Connor",

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -1,12 +1,13 @@
 #ifndef BOARD_HPP
 #define BOARD_HPP
 
+#include <array>
 #include <bitset>
 #include <vector>
 
-const unsigned int BOARD_SIZE = 19;
-const int BOARD_WIDTH = 20;  // 19 + 1 sentinel
-const int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
+constexpr int BOARD_SIZE = 19;
+constexpr int BOARD_WIDTH = 20;  // 19 + 1 sentinel
+constexpr int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
 
 enum class Player { NONE, BLACK, WHITE };
 
@@ -14,11 +15,14 @@ class Board {
  public:
   Board();
 
+  // ゲーム進行用
   bool makeMove(int x, int y);
+  void changeTurn();
+  bool checkWin();
+
+  // 状態取得用
   Player getStoneAt(int x, int y) const;
   Player getCurrentTurn() const;
-  bool checkWin();
-  void changeTurn();
   int getBlackCaptures() const;
   int getWhiteCaptures() const;
 
@@ -30,6 +34,8 @@ class Board {
   Player _currentTurn;
   int _blackCaptures;
   int _whiteCaptures;
+
+  // 方向定数
   static constexpr int SHIFT_H = 1;                 // 横
   static constexpr int SHIFT_V = BOARD_WIDTH;       // 縦 (20)
   static constexpr int SHIFT_D1 = BOARD_WIDTH + 1;  // 右下 (21)

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -10,6 +10,8 @@ const int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
 
 enum class Player { NONE, BLACK, WHITE };
 
+using BoardType = std::bitset<MAX_CELLS>;
+
 class Board {
  public:
   Board();
@@ -19,18 +21,23 @@ class Board {
   Player getCurrentTurn() const;
   bool checkWin();
   void changeTurn();
+  int getBlackCaptures() const;
+  int getWhiteCaptures() const;
 
  private:
-  std::bitset<MAX_CELLS> _blackStones;
-  std::bitset<MAX_CELLS> _whiteStones;
+  BoardType _blackStones;
+  BoardType _whiteStones;
   Player _currentTurn;
+  int _blackCaptures;
+  int _whiteCaptures;
   static constexpr int SHIFT_H = 1;                 // 横
   static constexpr int SHIFT_V = BOARD_WIDTH;       // 縦 (20)
   static constexpr int SHIFT_D1 = BOARD_WIDTH + 1;  // 右下 (21)
   static constexpr int SHIFT_D2 = BOARD_WIDTH - 1;  // 左下 (19)
 
   int _getIndex(int x, int y) const;
-  bool _hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amount) const;
+  bool _hasFiveInARow(const BoardType& stones, int shift_amount) const;
+  void _checkAndProcessCapture(int index);
 };
 
 #endif

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -10,8 +10,6 @@ const int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
 
 enum class Player { NONE, BLACK, WHITE };
 
-using BoardType = std::bitset<MAX_CELLS>;
-
 class Board {
  public:
   Board();
@@ -25,6 +23,8 @@ class Board {
   int getWhiteCaptures() const;
 
  private:
+  using BoardType = std::bitset<MAX_CELLS>;
+
   BoardType _blackStones;
   BoardType _whiteStones;
   Player _currentTurn;

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -34,10 +34,12 @@ class Board {
   static constexpr int SHIFT_V = BOARD_WIDTH;       // 縦 (20)
   static constexpr int SHIFT_D1 = BOARD_WIDTH + 1;  // 右下 (21)
   static constexpr int SHIFT_D2 = BOARD_WIDTH - 1;  // 左下 (19)
+  static constexpr std::array<int, 4> ALL_DIRS = {SHIFT_H, SHIFT_V, SHIFT_D1, SHIFT_D2};
 
   int _getIndex(int x, int y) const;
-  bool _hasFiveInARow(const BoardType& stones, int shift_amount) const;
   void _checkAndProcessCapture(int index);
+  BoardType _getFiveInARowBits(const BoardType& stones, int shift_amount) const;
+  bool _isStoneCapturable(int index, const BoardType& myStones, const BoardType& oppStones) const;
 };
 
 #endif

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -90,33 +90,116 @@ Player Board::getCurrentTurn() const {
   return _currentTurn;
 }
 
-bool Board::_hasFiveInARow(const BoardType& stones, int shift_amount) const {
+Board::BoardType Board::_getFiveInARowBits(const BoardType& stones, int shift_amount) const {
   BoardType temp = stones;
 
-  // 1回ずらしてANDをとる = 「2個並んでいる場所」が1になる
+  // 1回ずらしてAND = 2連
   temp &= (temp >> shift_amount);
   temp &= (temp >> shift_amount);  // 3連
   temp &= (temp >> shift_amount);  // 4連
   temp &= (temp >> shift_amount);  // 5連
 
-  return temp.any();
+  return temp;
+}
+
+bool Board::_isStoneCapturable(int index, const BoardType& myStones,
+                               const BoardType& oppStones) const {
+  // 全方向(4軸)をチェック
+  for (int dir : ALL_DIRS) {
+    // ペアのパターンは2通り: (自分, 相方) or (相方, 自分)
+    // 自分が index の位置にいるとして、相方が dir 方向にいるか、-dir 方向にいるか
+
+    // --- ケース1: [index] [相方(index+dir)] ---
+    int p_partner = index + dir;
+    if (p_partner < MAX_CELLS && myStones.test(p_partner)) {
+      // ペア発見。このペアは挟まれているか？
+      // 捕獲成立条件: (敵, ペア, 空) または (空, ペア, 敵)
+      // つまり、両端の一方が敵で、もう一方が空なら、相手は空に打って取れる。
+
+      int p_end1 = index - dir;      // ペアの左側
+      int p_end2 = p_partner + dir;  // ペアの右側
+
+      // 範囲チェック
+      bool end1_valid = (p_end1 >= 0 && p_end1 < MAX_CELLS);
+      bool end2_valid = (p_end2 >= 0 && p_end2 < MAX_CELLS);
+
+      // パターンA: [敵] [自] [自] [空]
+      if (end1_valid && end2_valid && oppStones.test(p_end1) && !myStones.test(p_end2) &&
+          !oppStones.test(p_end2)) {
+        return true;
+      }
+      // パターンB: [空] [自] [自] [敵]
+      if (end1_valid && end2_valid && !myStones.test(p_end1) && !oppStones.test(p_end1) &&
+          oppStones.test(p_end2)) {
+        return true;
+      }
+    }
+
+    // --- ケース2: [相方(index-dir)] [index] ---
+    // これは「ケース1」で dir を反転させてチェックするのと同じ
+    int p_prev = index - dir;
+    if (p_prev >= 0 && myStones.test(p_prev)) {
+      int p_end_left = p_prev - dir;
+      int p_end_right = index + dir;
+
+      bool left_valid = (p_end_left >= 0 && p_end_left < MAX_CELLS);
+      bool right_valid = (p_end_right >= 0 && p_end_right < MAX_CELLS);
+
+      // [敵] [自] [自] [空]
+      if (left_valid && right_valid && oppStones.test(p_end_left) && !myStones.test(p_end_right) &&
+          !oppStones.test(p_end_right)) {
+        return true;
+      }
+      // [空] [自] [自] [敵]
+      if (left_valid && right_valid && !myStones.test(p_end_left) && !oppStones.test(p_end_left) &&
+          oppStones.test(p_end_right)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 bool Board::checkWin() {
-  const BoardType& stones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
+  const auto& myStones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
+  const auto& oppStones = (_currentTurn == Player::WHITE) ? _blackStones : _whiteStones;
   int captures = (_currentTurn == Player::WHITE) ? _whiteCaptures : _blackCaptures;
 
+  // 1. 捕獲勝ち
   if (captures >= 10)
     return true;
 
-  if (_hasFiveInARow(stones, SHIFT_H))
-    return true;  // 横
-  if (_hasFiveInARow(stones, SHIFT_V))
-    return true;  // 縦
-  if (_hasFiveInARow(stones, SHIFT_D1))
-    return true;  // 右下
-  if (_hasFiveInARow(stones, SHIFT_D2))
-    return true;  // 左下
+  // 2. 5連チェック (4方向)
+  for (int shift : ALL_DIRS) {
+    // 5連の始点ビット列を取得
+    BoardType lines = _getFiveInARowBits(myStones, shift);
+
+    if (lines.none())
+      continue;
+
+    // 見つかった全ての5連ラインについて検証
+    for (int i = 0; i < MAX_CELLS; ++i) {
+      if (lines.test(i)) {
+        // インデックス i から始まる5連が見つかった
+        bool lineIsSafe = true;
+
+        // 5つの石すべてについて「捕獲される危険性」をチェック
+        for (int k = 0; k < 5; ++k) {
+          int stoneIdx = i + k * shift;
+          if (_isStoneCapturable(stoneIdx, myStones, oppStones)) {
+            // 一つでも捕獲される石があれば、このラインでの勝利は成立しない
+            lineIsSafe = false;
+            break;
+          }
+        }
+
+        // 一つでも「安全な5連」があれば勝利確定
+        if (lineIsSafe) {
+          return true;
+        }
+      }
+    }
+  }
 
   return false;
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -36,7 +36,10 @@ void Board::_checkAndProcessCapture(int index) {
       myScore += 2;
 
       // TODO: デバッグ用にログを出すと分かりやすい
-      std::cout << "Capture occurred at dir: " << dir << std::endl;
+      std::cout << "Capture! Player " << ((_currentTurn == Player::BLACK) ? "BLACK" : "WHITE")
+                << std::endl;
+      std::cout << "Total captures - BLACK: " << _blackCaptures << ", WHITE: " << _whiteCaptures
+                << std::endl;
     }
   }
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,59 +1,13 @@
-#include <Board.hpp>
+#include "Board.hpp"
+
 #include <iostream>  // TODO: デバッグ用
 
-Board::Board() : _currentTurn(Player::BLACK) {
-  _blackStones.reset();
-  _whiteStones.reset();
-}
-
-const std::vector<int> DIRECTIONS = {1, -1, 20, -20, 21, -21, 19, -19};
-
-void Board::_checkAndProcessCapture(int index) {
-  // 今の手番（石を置いた人）と相手のビットボードを取得
-  auto& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
-  auto& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
-  int& myScore = (_currentTurn == Player::BLACK) ? _blackCaptures : _whiteCaptures;
-
-  for (int dir : DIRECTIONS) {
-    // パターン: [自(index)] [敵] [敵] [自]
-    int p1 = index + dir;      // 隣
-    int p2 = index + dir * 2;  // 2つ隣
-    int p3 = index + dir * 3;  // 3つ隣
-
-    // ビットボードの範囲内かどうか簡易チェック（配列外アクセス防止）
-    if (p3 < 0 || p3 >= MAX_CELLS)
-      continue;
-
-    // 判定ロジック:
-    // 1. 隣と2つ隣が「敵」である
-    // 2. 3つ隣が「自分」である
-    if (oppStones.test(p1) && oppStones.test(p2) && myStones.test(p3)) {
-      // 捕獲成立！敵の石を消す
-      oppStones.reset(p1);
-      oppStones.reset(p2);
-
-      // スコア加算（石2個分）
-      myScore += 2;
-
-      // TODO: デバッグ用にログを出すと分かりやすい
-      std::cout << "Capture! Player " << ((_currentTurn == Player::BLACK) ? "BLACK" : "WHITE")
-                << std::endl;
-      std::cout << "Total captures - BLACK: " << _blackCaptures << ", WHITE: " << _whiteCaptures
-                << std::endl;
-    }
-  }
-}
-
-void Board::changeTurn() {
-  _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
-}
-
-int Board::getBlackCaptures() const {
-  return _blackCaptures;
-}
-
-int Board::getWhiteCaptures() const {
-  return _whiteCaptures;
+Board::Board()
+    : _blackStones(0),
+      _whiteStones(0),
+      _currentTurn(Player::BLACK),
+      _blackCaptures(0),
+      _whiteCaptures(0) {
 }
 
 bool Board::makeMove(int x, int y) {
@@ -62,9 +16,8 @@ bool Board::makeMove(int x, int y) {
 
   int index = _getIndex(x, y);
 
-  if (_blackStones.test(index) || _whiteStones.test(index)) {
+  if (_blackStones.test(index) || _whiteStones.test(index))
     return false;
-  }
 
   if (_currentTurn == Player::BLACK) {
     _blackStones.set(index);
@@ -77,87 +30,8 @@ bool Board::makeMove(int x, int y) {
   return true;
 }
 
-Player Board::getStoneAt(int x, int y) const {
-  int index = _getIndex(x, y);
-  if (_blackStones.test(index))
-    return Player::BLACK;
-  if (_whiteStones.test(index))
-    return Player::WHITE;
-  return Player::NONE;
-}
-
-Player Board::getCurrentTurn() const {
-  return _currentTurn;
-}
-
-Board::BoardType Board::_getFiveInARowBits(const BoardType& stones, int shift_amount) const {
-  BoardType temp = stones;
-
-  // 1回ずらしてAND = 2連
-  temp &= (temp >> shift_amount);
-  temp &= (temp >> shift_amount);  // 3連
-  temp &= (temp >> shift_amount);  // 4連
-  temp &= (temp >> shift_amount);  // 5連
-
-  return temp;
-}
-
-bool Board::_isStoneCapturable(int index, const BoardType& myStones,
-                               const BoardType& oppStones) const {
-  // 全方向(4軸)をチェック
-  for (int dir : ALL_DIRS) {
-    // ペアのパターンは2通り: (自分, 相方) or (相方, 自分)
-    // 自分が index の位置にいるとして、相方が dir 方向にいるか、-dir 方向にいるか
-
-    // --- ケース1: [index] [相方(index+dir)] ---
-    int p_partner = index + dir;
-    if (p_partner < MAX_CELLS && myStones.test(p_partner)) {
-      // ペア発見。このペアは挟まれているか？
-      // 捕獲成立条件: (敵, ペア, 空) または (空, ペア, 敵)
-      // つまり、両端の一方が敵で、もう一方が空なら、相手は空に打って取れる。
-
-      int p_end1 = index - dir;      // ペアの左側
-      int p_end2 = p_partner + dir;  // ペアの右側
-
-      // 範囲チェック
-      bool end1_valid = (p_end1 >= 0 && p_end1 < MAX_CELLS);
-      bool end2_valid = (p_end2 >= 0 && p_end2 < MAX_CELLS);
-
-      // パターンA: [敵] [自] [自] [空]
-      if (end1_valid && end2_valid && oppStones.test(p_end1) && !myStones.test(p_end2) &&
-          !oppStones.test(p_end2)) {
-        return true;
-      }
-      // パターンB: [空] [自] [自] [敵]
-      if (end1_valid && end2_valid && !myStones.test(p_end1) && !oppStones.test(p_end1) &&
-          oppStones.test(p_end2)) {
-        return true;
-      }
-    }
-
-    // --- ケース2: [相方(index-dir)] [index] ---
-    // これは「ケース1」で dir を反転させてチェックするのと同じ
-    int p_prev = index - dir;
-    if (p_prev >= 0 && myStones.test(p_prev)) {
-      int p_end_left = p_prev - dir;
-      int p_end_right = index + dir;
-
-      bool left_valid = (p_end_left >= 0 && p_end_left < MAX_CELLS);
-      bool right_valid = (p_end_right >= 0 && p_end_right < MAX_CELLS);
-
-      // [敵] [自] [自] [空]
-      if (left_valid && right_valid && oppStones.test(p_end_left) && !myStones.test(p_end_right) &&
-          !oppStones.test(p_end_right)) {
-        return true;
-      }
-      // [空] [自] [自] [敵]
-      if (left_valid && right_valid && !myStones.test(p_end_left) && !oppStones.test(p_end_left) &&
-          oppStones.test(p_end_right)) {
-        return true;
-      }
-    }
-  }
-  return false;
+void Board::changeTurn() {
+  _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
 }
 
 bool Board::checkWin() {
@@ -205,6 +79,127 @@ bool Board::checkWin() {
   return false;
 }
 
+// --- Getters ---
+
+Player Board::getStoneAt(int x, int y) const {
+  int index = _getIndex(x, y);
+  if (_blackStones.test(index))
+    return Player::BLACK;
+  if (_whiteStones.test(index))
+    return Player::WHITE;
+  return Player::NONE;
+}
+
+Player Board::getCurrentTurn() const {
+  return _currentTurn;
+}
+
+int Board::getBlackCaptures() const {
+  return _blackCaptures;
+}
+
+int Board::getWhiteCaptures() const {
+  return _whiteCaptures;
+}
+
+// --- Private Helpers ---
+
 int Board::_getIndex(int x, int y) const {
   return y * BOARD_WIDTH + x;
+}
+
+void Board::_checkAndProcessCapture(int index) {
+  auto& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
+  auto& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
+  int& myScore = (_currentTurn == Player::BLACK) ? _blackCaptures : _whiteCaptures;
+
+  for (int d : ALL_DIRS) {
+    const int directions[] = {d, -d};
+
+    for (int dir : directions) {
+      // パターン: [自(index)] [敵] [敵] [自]
+      int p1 = index + dir;      // 隣
+      int p2 = index + dir * 2;  // 2つ隣
+      int p3 = index + dir * 3;  // 3つ隣
+
+      // 範囲チェック
+      if (p3 < 0 || p3 >= MAX_CELLS)
+        continue;
+
+      // 判定ロジック:
+      // 1. 隣と2つ隣が「敵」
+      // 2. 3つ隣が「自分」
+      if (oppStones.test(p1) && oppStones.test(p2) && myStones.test(p3)) {
+        // 捕獲成立！敵の石を消す
+        oppStones.reset(p1);
+        oppStones.reset(p2);
+
+        // スコア加算
+        myScore += 2;
+
+        // TODO: Debug output
+        std::cout << "Capture! Player " << ((_currentTurn == Player::BLACK) ? "BLACK" : "WHITE")
+                  << "\n"
+                  << "Total captures - BLACK: " << _blackCaptures << ", WHITE: " << _whiteCaptures
+                  << std::endl;
+      }
+    }
+  }
+}
+
+Board::BoardType Board::_getFiveInARowBits(const BoardType& stones, int shift_amount) const {
+  BoardType temp = stones;
+
+  // 1回ずらしてAND = 2連
+  temp &= (temp >> shift_amount);
+  temp &= (temp >> shift_amount);  // 3連
+  temp &= (temp >> shift_amount);  // 4連
+  temp &= (temp >> shift_amount);  // 5連
+
+  return temp;
+}
+
+bool Board::_isStoneCapturable(int index, const BoardType& myStones,
+                               const BoardType& oppStones) const {
+  // 全方向(4軸)をチェック
+  for (int dir : ALL_DIRS) {
+    // インデックスを中心とした両側 (+dir, -dir) をチェック
+    const int sides[] = {dir, -dir};
+
+    for (int d : sides) {
+      int p_partner = index + d;
+
+      // 1. 配列範囲チェック
+      if (p_partner < 0 || p_partner >= MAX_CELLS)
+        continue;
+
+      // 2. 隣が自分の石(=ペア成立)かチェック
+      if (myStones.test(p_partner)) {
+        // ペア: [index] [p_partner]
+        // このペアの両外側: (index - d) と (p_partner + d)
+        int p_outer_self = index - d;
+        int p_outer_partner = p_partner + d;
+
+        // 範囲外チェック
+        if (p_outer_self < 0 || p_outer_self >= MAX_CELLS)
+          continue;
+        if (p_outer_partner < 0 || p_outer_partner >= MAX_CELLS)
+          continue;
+
+        // 状態取得
+        // 捕獲条件: (敵, ペア, 空) または (空, ペア, 敵)
+        bool self_side_enemy = oppStones.test(p_outer_self);
+        bool partner_side_enemy = oppStones.test(p_outer_partner);
+
+        // 敵でなく、かつ自分の石でもなければ「空」
+        bool self_side_empty = !self_side_enemy && !myStones.test(p_outer_self);
+        bool partner_side_empty = !partner_side_enemy && !myStones.test(p_outer_partner);
+
+        if ((self_side_enemy && partner_side_empty) || (self_side_empty && partner_side_enemy)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -189,6 +189,7 @@ bool Board::checkWin() {
           if (_isStoneCapturable(stoneIdx, myStones, oppStones)) {
             // 一つでも捕獲される石があれば、このラインでの勝利は成立しない
             lineIsSafe = false;
+            std::cout << "Capturable!!" << std::endl;  // TODO: デバッグ用
             break;
           }
         }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,12 +1,56 @@
 #include <Board.hpp>
+#include <iostream>  // TODO: デバッグ用
 
 Board::Board() : _currentTurn(Player::BLACK) {
   _blackStones.reset();
   _whiteStones.reset();
 }
 
+const std::vector<int> DIRECTIONS = {1, -1, 20, -20, 21, -21, 19, -19};
+
+void Board::_checkAndProcessCapture(int index) {
+  // 今の手番（石を置いた人）と相手のビットボードを取得
+  auto& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
+  auto& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
+  int& myScore = (_currentTurn == Player::BLACK) ? _blackCaptures : _whiteCaptures;
+
+  for (int dir : DIRECTIONS) {
+    // パターン: [自(index)] [敵] [敵] [自]
+    int p1 = index + dir;      // 隣
+    int p2 = index + dir * 2;  // 2つ隣
+    int p3 = index + dir * 3;  // 3つ隣
+
+    // ビットボードの範囲内かどうか簡易チェック（配列外アクセス防止）
+    if (p3 < 0 || p3 >= MAX_CELLS)
+      continue;
+
+    // 判定ロジック:
+    // 1. 隣と2つ隣が「敵」である
+    // 2. 3つ隣が「自分」である
+    if (oppStones.test(p1) && oppStones.test(p2) && myStones.test(p3)) {
+      // 捕獲成立！敵の石を消す
+      oppStones.reset(p1);
+      oppStones.reset(p2);
+
+      // スコア加算（石2個分）
+      myScore += 2;
+
+      // TODO: デバッグ用にログを出すと分かりやすい
+      std::cout << "Capture occurred at dir: " << dir << std::endl;
+    }
+  }
+}
+
 void Board::changeTurn() {
   _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
+}
+
+int Board::getBlackCaptures() const {
+  return _blackCaptures;
+}
+
+int Board::getWhiteCaptures() const {
+  return _whiteCaptures;
 }
 
 bool Board::makeMove(int x, int y) {
@@ -25,6 +69,8 @@ bool Board::makeMove(int x, int y) {
     _whiteStones.set(index);
   }
 
+  _checkAndProcessCapture(index);
+
   return true;
 }
 
@@ -41,8 +87,8 @@ Player Board::getCurrentTurn() const {
   return _currentTurn;
 }
 
-bool Board::_hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amount) const {
-  std::bitset<MAX_CELLS> temp = stones;
+bool Board::_hasFiveInARow(const BoardType& stones, int shift_amount) const {
+  BoardType temp = stones;
 
   // 1回ずらしてANDをとる = 「2個並んでいる場所」が1になる
   temp &= (temp >> shift_amount);
@@ -54,7 +100,11 @@ bool Board::_hasFiveInARow(const std::bitset<MAX_CELLS>& stones, int shift_amoun
 }
 
 bool Board::checkWin() {
-  const auto& stones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
+  const BoardType& stones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
+  int captures = (_currentTurn == Player::WHITE) ? _whiteCaptures : _blackCaptures;
+
+  if (captures >= 10)
+    return true;
 
   if (_hasFiveInARow(stones, SHIFT_H))
     return true;  // 横


### PR DESCRIPTION
# 概要

Capturesというルールを追加しました。ルール概要は以下の通り
- 条件: `自分 敵 敵 自分` と並んだ瞬間、間の `敵 敵` を盤面から取り除く
- 勝利条件の追加: 石を合計 10個（5ペア） 捕獲したら、その時点で勝利

さらに、勝利判定が次のように変更されました
- 5連を作っても、次の相手の手番でそのラインの一部（ペア）を捕獲されて崩される場合は、まだ勝利ではない

## 変更点

- `Board.cpp, Board.hpp` のみ変更しています。新しい関数や変数を追加しました。

## 影響範囲

勝利判定ロジックなどゲーム動作に影響します。`Board`クラスしか変更していないので、UI等に影響はないです。

## テスト

- 捕獲ができるか
- 捕獲数が10を超えた瞬間ゲームが終了するか
- 五連を作成しても次の手で捕獲できる時の判定がきちっとできているか
    - その場合、五連以上を作成できるはず

## 依頼

- 捕獲数を常に盤面外に表示できるとより良い気がしています
- 五連を作成したのに終了しない（五連に捕獲対象の碁がある）時は特殊なUIにしてもいいかなと思いました

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx

