### PR TITLE
Feat: Implement double free three check

### DIFF
--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -11,6 +11,11 @@ constexpr int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
 
 enum class Player { NONE, BLACK, WHITE };
 
+struct Direction {
+  int dx;
+  int dy;
+};
+
 class Board {
  public:
   Board();
@@ -41,6 +46,13 @@ class Board {
   static constexpr int SHIFT_D1 = BOARD_WIDTH + 1;  // 右下 (21)
   static constexpr int SHIFT_D2 = BOARD_WIDTH - 1;  // 左下 (19)
   static constexpr std::array<int, 4> ALL_DIRS = {SHIFT_H, SHIFT_V, SHIFT_D1, SHIFT_D2};
+
+  static constexpr std::array<Direction, 4> CHECK_DIRS = {{
+      {1, 0},  // Horizontal
+      {0, 1},  // Vertical
+      {1, 1},  // Diagonal Down-Right
+      {-1, 1}  // Diagonal Down-Left
+  }};
 
   int _getIndex(int x, int y) const;
   bool _checkAndProcessCapture(int index);

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -30,6 +30,8 @@ class Board {
   Player getCurrentTurn() const;
   int getBlackCaptures() const;
   int getWhiteCaptures() const;
+  bool getDoubleThreeStatus() const;
+  void setDoubleThreeStatus(bool status);
 
  private:
   using BoardType = std::bitset<MAX_CELLS>;
@@ -39,6 +41,7 @@ class Board {
   Player _currentTurn;
   int _blackCaptures;
   int _whiteCaptures;
+  bool _doubleThreeStatus;
 
   // 方向定数
   static constexpr int SHIFT_H = 1;                 // 横

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -43,9 +43,12 @@ class Board {
   static constexpr std::array<int, 4> ALL_DIRS = {SHIFT_H, SHIFT_V, SHIFT_D1, SHIFT_D2};
 
   int _getIndex(int x, int y) const;
-  void _checkAndProcessCapture(int index);
+  bool _checkAndProcessCapture(int index);
   BoardType _getFiveInARowBits(const BoardType& stones, int shift_amount) const;
   bool _isStoneCapturable(int index, const BoardType& myStones, const BoardType& oppStones) const;
+  bool _checkFreeThree(int x, int y, int dir_x, int dir_y, const BoardType& myStones,
+                       const BoardType& oppStones) const;
+  bool _isDoubleThree(int x, int y);
 };
 
 #endif

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -212,68 +212,92 @@ bool Board::_isStoneCapturable(int index, const BoardType& myStones,
 }
 
 bool Board::_isDoubleThree(int x, int y) {
-  // 現在の手番
   const BoardType& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
   const BoardType& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
 
   int freeThreeCount = 0;
 
   // 4方向チェック
-  // 横(1,0), 縦(0,1), 右下(1,1), 左下(-1,1)
-  const int dirs[4][2] = {{1, 0}, {0, 1}, {1, 1}, {-1, 1}};
-
-  for (auto& d : dirs) {
-    if (_checkFreeThree(x, y, d[0], d[1], myStones, oppStones)) {
+  for (auto& dir : CHECK_DIRS) {
+    if (_checkFreeThree(x, y, dir.dx, dir.dy, myStones, oppStones))
       freeThreeCount++;
-    }
+    if (freeThreeCount >= 2)
+      break;
   }
 
   return (freeThreeCount >= 2);
 }
 
-// 核心部分: ある方向についてのFree-Three判定
 bool Board::_checkFreeThree(int x, int y, int dx, int dy, const BoardType& myStones,
                             const BoardType& oppStones) const {
-  // (x,y) を中心に、-4 〜 +4 の範囲の状態を取得
-  // 0:空, 1:自分, 2:敵/壁
-  int line[9];
-  int center = 4;  // line[4] が (x,y)
+  // bit 5 を中心 (x,y) とする
+  uint16_t line_m = 0;  // m = my
+  uint16_t line_o = 0;  // o = opponent
 
-  for (int i = -4; i <= 4; ++i) {
+  // ±5マスを取得 (計11マス)
+  // Free-Threeパターンの最大長は .X.XX. (6マス) なのでこれで十分
+  for (int i = -5; i <= 5; ++i) {
+    if (i == 0) {
+      line_m |= (1 << 5);  // 中心は自分
+      continue;
+    }
+
     int nx = x + i * dx;
     int ny = y + i * dy;
-    int idx = _getIndex(nx, ny);  // 範囲外なら-1などを返す工夫が必要
 
     // 範囲外チェック
     if (nx < 0 || nx >= BOARD_SIZE || ny < 0 || ny >= BOARD_SIZE) {
-      line[center + i] = 2;  // 壁は敵と同じ扱い
+      line_o |= (1 << (i + 5));  // 壁
     } else {
+      int idx = _getIndex(nx, ny);
       if (myStones.test(idx))
-        line[center + i] = 1;
+        line_m |= (1 << (i + 5));
       else if (oppStones.test(idx))
-        line[center + i] = 2;
-      else
-        line[center + i] = 0;
+        line_o |= (1 << (i + 5));
     }
   }
 
-  // (x,y)にはまだ石がない前提だが、置いたとして判定するので
-  line[center] = 1;
+  // パターン定義 (1:石, 0:空)
+  // bit 0 が左端
+  static const uint16_t patterns[] = {
+      0b001110,  // .XXX.  (連三)
+      0b010110,  // .X.XX. (飛び三 A)
+      0b011010   // .XX.X. (飛び三 B)
+  };
 
-  // パターンマッチング
-  // Free-Threeの定義: 「止めなければ4連になり」かつ「両端が空いている」
-  // つまり、少なくとも5マスの範囲を見る必要があります。
+  // 各パターンを盤面上でスライドさせて照合
+  for (uint16_t p : patterns) {
+    // パターンの長さは6ビット (0b000000 ~ 0b111111)
+    // これを line_m, line_o に対してずらしながらチェック
 
-  // 代表的なFree-Threeパターン:
-  // A: . X X X .  (Open Three)
-  // B: . X . X X . (Split Three)
+    // パターンの位置をスライド (ウィンドウ)
+    // line_m の幅は11ビット (0..10)。パターンは6ビット。
+    // i はパターンの開始位置 (0..5)
+    for (int i = 0; i <= 5; ++i) {
+      uint16_t mask = 0b111111 << i;
+      uint16_t target = p << i;
 
-  // これを検出するロジック
-  // ここは少し泥臭いですが、配列 line[] を走査して
-  // 「自分の石が3つ」かつ「両端が空」かつ「敵に邪魔されていない」を探します。
+      // 1. 自分の石の形が一致するか？
+      // マスク範囲内の石配置がパターンと完全一致すること
+      // (パターン内の0は「石がない」ことを要求)
+      if ((line_m & mask) != target)
+        continue;
 
-  // 実装例: 文字列変換してfindするのも手です
-  // "01110", "010110", "011010" など
+      // 2. 敵の石（壁）がないか？
+      // マスク範囲内は敵がゼロでなければならない（両端の空も含めて）
+      if ((line_o & mask) != 0)
+        continue;
 
-  return false;  // 仮
+      // 3. 中心 (bit 5) がパターンに含まれているか？
+      // 今置いた石が、そのFree-Threeの一部でなければならない
+      // target (シフト済みのパターン) の bit 5 が 1 であるか確認
+      if ((target & (1 << 5)) == 0)
+        continue;
+
+      // すべてクリアならFree-Three
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -35,8 +35,8 @@ void Board::changeTurn() {
 }
 
 bool Board::checkWin() {
-  const auto& myStones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
-  const auto& oppStones = (_currentTurn == Player::WHITE) ? _blackStones : _whiteStones;
+  const BoardType& myStones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
+  const BoardType& oppStones = (_currentTurn == Player::WHITE) ? _blackStones : _whiteStones;
   int captures = (_currentTurn == Player::WHITE) ? _whiteCaptures : _blackCaptures;
 
   // 1. 捕獲勝ち
@@ -109,8 +109,8 @@ int Board::_getIndex(int x, int y) const {
 }
 
 void Board::_checkAndProcessCapture(int index) {
-  auto& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
-  auto& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
+  BoardType& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
+  BoardType& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
   int& myScore = (_currentTurn == Player::BLACK) ? _blackCaptures : _whiteCaptures;
 
   for (int d : ALL_DIRS) {

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -19,13 +19,16 @@ bool Board::makeMove(int x, int y) {
   if (_blackStones.test(index) || _whiteStones.test(index))
     return false;
 
+  if (!_checkAndProcessCapture(index)) {
+    if (_isDoubleThree(x, y))
+      return false;
+  }
+
   if (_currentTurn == Player::BLACK) {
     _blackStones.set(index);
   } else {
     _whiteStones.set(index);
   }
-
-  _checkAndProcessCapture(index);
 
   return true;
 }
@@ -108,10 +111,11 @@ int Board::_getIndex(int x, int y) const {
   return y * BOARD_WIDTH + x;
 }
 
-void Board::_checkAndProcessCapture(int index) {
+bool Board::_checkAndProcessCapture(int index) {
   BoardType& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
   BoardType& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
   int& myScore = (_currentTurn == Player::BLACK) ? _blackCaptures : _whiteCaptures;
+  bool captured = false;
 
   for (int d : ALL_DIRS) {
     const int directions[] = {d, -d};
@@ -137,6 +141,8 @@ void Board::_checkAndProcessCapture(int index) {
         // スコア加算
         myScore += 2;
 
+        captured = true;
+
         // TODO: Debug output
         std::cout << "Capture! Player " << ((_currentTurn == Player::BLACK) ? "BLACK" : "WHITE")
                   << "\n"
@@ -145,6 +151,7 @@ void Board::_checkAndProcessCapture(int index) {
       }
     }
   }
+  return captured;
 }
 
 Board::BoardType Board::_getFiveInARowBits(const BoardType& stones, int shift_amount) const {
@@ -202,4 +209,71 @@ bool Board::_isStoneCapturable(int index, const BoardType& myStones,
     }
   }
   return false;
+}
+
+bool Board::_isDoubleThree(int x, int y) {
+  // 現在の手番
+  const BoardType& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
+  const BoardType& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
+
+  int freeThreeCount = 0;
+
+  // 4方向チェック
+  // 横(1,0), 縦(0,1), 右下(1,1), 左下(-1,1)
+  const int dirs[4][2] = {{1, 0}, {0, 1}, {1, 1}, {-1, 1}};
+
+  for (auto& d : dirs) {
+    if (_checkFreeThree(x, y, d[0], d[1], myStones, oppStones)) {
+      freeThreeCount++;
+    }
+  }
+
+  return (freeThreeCount >= 2);
+}
+
+// 核心部分: ある方向についてのFree-Three判定
+bool Board::_checkFreeThree(int x, int y, int dx, int dy, const BoardType& myStones,
+                            const BoardType& oppStones) const {
+  // (x,y) を中心に、-4 〜 +4 の範囲の状態を取得
+  // 0:空, 1:自分, 2:敵/壁
+  int line[9];
+  int center = 4;  // line[4] が (x,y)
+
+  for (int i = -4; i <= 4; ++i) {
+    int nx = x + i * dx;
+    int ny = y + i * dy;
+    int idx = _getIndex(nx, ny);  // 範囲外なら-1などを返す工夫が必要
+
+    // 範囲外チェック
+    if (nx < 0 || nx >= BOARD_SIZE || ny < 0 || ny >= BOARD_SIZE) {
+      line[center + i] = 2;  // 壁は敵と同じ扱い
+    } else {
+      if (myStones.test(idx))
+        line[center + i] = 1;
+      else if (oppStones.test(idx))
+        line[center + i] = 2;
+      else
+        line[center + i] = 0;
+    }
+  }
+
+  // (x,y)にはまだ石がない前提だが、置いたとして判定するので
+  line[center] = 1;
+
+  // パターンマッチング
+  // Free-Threeの定義: 「止めなければ4連になり」かつ「両端が空いている」
+  // つまり、少なくとも5マスの範囲を見る必要があります。
+
+  // 代表的なFree-Threeパターン:
+  // A: . X X X .  (Open Three)
+  // B: . X . X X . (Split Three)
+
+  // これを検出するロジック
+  // ここは少し泥臭いですが、配列 line[] を走査して
+  // 「自分の石が3つ」かつ「両端が空」かつ「敵に邪魔されていない」を探します。
+
+  // 実装例: 文字列変換してfindするのも手です
+  // "01110", "010110", "011010" など
+
+  return false;  // 仮
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -7,7 +7,8 @@ Board::Board()
       _whiteStones(0),
       _currentTurn(Player::BLACK),
       _blackCaptures(0),
-      _whiteCaptures(0) {
+      _whiteCaptures(0),
+      _doubleThreeStatus(false) {
 }
 
 bool Board::makeMove(int x, int y) {
@@ -103,6 +104,14 @@ int Board::getBlackCaptures() const {
 
 int Board::getWhiteCaptures() const {
   return _whiteCaptures;
+}
+
+bool Board::getDoubleThreeStatus() const {
+  return _doubleThreeStatus;
+}
+
+void Board::setDoubleThreeStatus(bool status) {
+  _doubleThreeStatus = status;
 }
 
 // --- Private Helpers ---
@@ -221,8 +230,10 @@ bool Board::_isDoubleThree(int x, int y) {
   for (auto& dir : CHECK_DIRS) {
     if (_checkFreeThree(x, y, dir.dx, dir.dy, myStones, oppStones))
       freeThreeCount++;
-    if (freeThreeCount >= 2)
+    if (freeThreeCount >= 2) {
+      _doubleThreeStatus = true;
       break;
+    }
   }
 
   return (freeThreeCount >= 2);

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -27,24 +27,20 @@ void GameScene::handleClick(int x, int y) {
   if (col >= 0 && col < static_cast<int>(_boardSize) && row >= 0 &&
       row < static_cast<int>(_boardSize)) {
     // makeMoveが成功（ルール上OK）なら、内部状態が更新される
+    float posX = _boardOffset.x + static_cast<float>(col * _cellSize);
+    float posY = _boardOffset.y + static_cast<float>(row * _cellSize);
     if (_board.makeMove(col, row)) {
-      float posX = _boardOffset.x + static_cast<float>(col * _cellSize);
-      float posY = _boardOffset.y + static_cast<float>(row * _cellSize);
-      // static bool fg = false;
-      // fg = !fg;
-      // displayTimedMessage(fg ? "Hello" : "World", {posX, posY});
-
-      // TODO: SEを鳴らすなどの処理があればここに書く
-
       if (_board.checkWin()) {
-        // TODO: debug用
-        printf("Player %s wins!\n", _board.getCurrentTurn() == Player::BLACK ? "Black" : "White");
         std::string winner = _board.getCurrentTurn() == Player::BLACK ? "Black" : "White";
         if (_onGameOver)
           _onGameOver(winner);
       }
 
       _board.changeTurn();
+    }
+    if (_board.getDoubleThreeStatus()) {
+      displayTimedMessage("DoubleThree", {posX, posY});
+      _board.setDoubleThreeStatus(false);  // リセット
     }
   }
 }


### PR DESCRIPTION
# 概要
サブジェクトにある2つ目のルール **Double-Free-threes** を実装しました

### Free Three の定義
- **基本定義:**
    縦・横・斜めのいずれかのラインにおいて、同色の石が3つ並んでおり、かつ両端が空点で、相手の石や盤端（壁）に止められていない状態
- **成立条件（判定基準）:**
    次に石を一つ置くことで、両端が空いた4連（棒四）を作ることができる形であること。 ※端が止まっている場合や、次に棒四になれない形は Free Threeには含まれない。
- 具体的なパターン コード内では以下の3つの形状を判定対象とする（. は空点を表す）：
    - 連三 (Continuous Three): `. X X X .` 3つの石が連続して並んでいる形。
    - 飛び三 (Jump Three Type A): `. X . X X .` 石の間に1つの空点を挟んで並んでいる形。
    - 飛び三 (Jump Three Type B): `. X X . X .` Type Aの逆形。
- **禁じ手との関係:**
    この「Free Three」が同時に2つ以上形成される手は **Double Three** となり、禁じ手（反則負け）となる

## 変更点

- 基本は Board クラスの変更のみ
- 禁じ手であることをUI上でも明示するために、`GameScene.cpp` も一部変更した

## 影響範囲

ゲームロジック全体

## テスト

- さまざまな Double Three となる場合を実際に試して欲しい

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
