### PR TITLE
捕獲数をUIに表示

### DIFF
--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -45,6 +45,8 @@ class GameScene : public Scene {
   void handleClick(int x, int y);
   void displayTimedMessage(const std::string& message, sf::Vector2f pos);
   std::function<void(const std::string& winner)> _onGameOver;
+  sf::Text _countWhiteCaptures;
+  sf::Text _countBlackCaptures;
 };
 
 #endif

--- a/include/Theme.hpp
+++ b/include/Theme.hpp
@@ -18,6 +18,7 @@ const sf::Color AlertText = sf::Color(180, 50, 50);
 namespace FontSize {
 const unsigned int Title = 80;
 const unsigned int Header = 45;
+const unsigned int Text = 35;
 const unsigned int Button = 25;
 }  // namespace FontSize
 

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -1,6 +1,16 @@
 #include <GameScene.hpp>
 
-GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize) : _font(font) {
+GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize)
+    : _font(font),
+      _countWhiteCaptures(font, "White Captured: 0"),
+      _countBlackCaptures(font, "Black Captured: 0") {
+  this->_countWhiteCaptures.setCharacterSize(Theme::FontSize::Text);
+  this->_countWhiteCaptures.setFillColor(Theme::Color::Text);
+  this->_countWhiteCaptures.setOrigin(this->_countWhiteCaptures.getGlobalBounds().getCenter());
+
+  this->_countBlackCaptures.setCharacterSize(Theme::FontSize::Text);
+  this->_countBlackCaptures.setFillColor(Theme::Color::Text);
+  this->_countBlackCaptures.setOrigin(this->_countBlackCaptures.getGlobalBounds().getCenter());
   onResize(initalSize);
 }
 
@@ -30,6 +40,10 @@ void GameScene::handleClick(int x, int y) {
     float posX = _boardOffset.x + static_cast<float>(col * _cellSize);
     float posY = _boardOffset.y + static_cast<float>(row * _cellSize);
     if (_board.makeMove(col, row)) {
+      int whiteCaptures = this->_board.getWhiteCaptures();
+      int blackCaptures = this->_board.getBlackCaptures();
+      this->_countWhiteCaptures.setString("White Captured: " + std::to_string(whiteCaptures));
+      this->_countBlackCaptures.setString("Black Captured: " + std::to_string(blackCaptures));
       if (_board.checkWin()) {
         std::string winner = _board.getCurrentTurn() == Player::BLACK ? "Black" : "White";
         if (_onGameOver)
@@ -84,6 +98,8 @@ void GameScene::render(sf::RenderWindow& window) {
   for (const auto& message : this->_activeMessages) {
     window.draw(message.text);
   }
+  window.draw(this->_countWhiteCaptures);
+  window.draw(this->_countBlackCaptures);
 }
 
 void GameScene::update(float df) {
@@ -123,6 +139,9 @@ void GameScene::onResize(const sf::Vector2u& windowSize) {
   // (画面幅 - 盤面幅) / 2 = 左側の余白
   _boardOffset.x = (w - boardPixelSize) / 2.f;
   _boardOffset.y = (h - boardPixelSize) / 2.f;
+
+  this->_countWhiteCaptures.setPosition({w / 4.f, h / 9.5f});
+  this->_countBlackCaptures.setPosition({w * 3 / 4.f, h / 9.5f});
 }
 
 void GameScene::setOnGameOver(std::function<void(const std::string& winner)> callback) {


### PR DESCRIPTION
# 概要
すごく簡易的に捕獲数を画面表示しました

## 変更点

- GameSceneで捕獲数を表示できるようにsf::Textwを追加
- Theme::FontSizeにTextを追加

## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- 捕獲数がUI上に反映されること
- 捕獲数が10になった時にリザルト画面で数が10になってること

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
