### PR TITLE
捕獲した時にメッセージを表示

### DIFF
--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -31,6 +31,7 @@ class Board {
   int getBlackCaptures() const;
   int getWhiteCaptures() const;
   bool getDoubleThreeStatus() const;
+  bool getCapturedStatus() const;
   void setDoubleThreeStatus(bool status);
 
  private:
@@ -42,6 +43,7 @@ class Board {
   int _blackCaptures;
   int _whiteCaptures;
   bool _doubleThreeStatus;
+  bool _capturedStatus;
 
   // 方向定数
   static constexpr int SHIFT_H = 1;                 // 横

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -20,7 +20,8 @@ bool Board::makeMove(int x, int y) {
   if (_blackStones.test(index) || _whiteStones.test(index))
     return false;
 
-  if (!_checkAndProcessCapture(index)) {
+  this->_capturedStatus = _checkAndProcessCapture(index);
+  if (!_capturedStatus) {
     if (_isDoubleThree(x, y))
       return false;
   }
@@ -108,6 +109,10 @@ int Board::getWhiteCaptures() const {
 
 bool Board::getDoubleThreeStatus() const {
   return _doubleThreeStatus;
+}
+
+bool Board::getCapturedStatus() const {
+  return this->_capturedStatus;
 }
 
 void Board::setDoubleThreeStatus(bool status) {

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -30,12 +30,14 @@ void GameScene::handleClick(int x, int y) {
     float posX = _boardOffset.x + static_cast<float>(col * _cellSize);
     float posY = _boardOffset.y + static_cast<float>(row * _cellSize);
     if (_board.makeMove(col, row)) {
+      if (_board.getCapturedStatus()) {
+        displayTimedMessage("Capture", {posX, posY});
+      }
       if (_board.checkWin()) {
         std::string winner = _board.getCurrentTurn() == Player::BLACK ? "Black" : "White";
         if (_onGameOver)
           _onGameOver(winner);
       }
-
       _board.changeTurn();
     }
     if (_board.getDoubleThreeStatus()) {


### PR DESCRIPTION
# 概要
捕獲した時にDouble threeと同様にメッセージを出すようにしました。

## 変更点

- GameSceneに表示ロジックを追加
- BoardにCapturedStatusとゲッターを追加


## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- 捕獲をしてメッセージが表示されるか試してください

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
