### PR TITLE
人間のターンで画面上に通知を表示

### DIFF
--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -1,15 +1,18 @@
 #ifndef BOARD_HPP
 #define BOARD_HPP
 
+#include <Enums.hpp>
 #include <array>
 #include <bitset>
+#include <map>
 #include <vector>
 
 constexpr int BOARD_SIZE = 19;
 constexpr int BOARD_WIDTH = 20;  // 19 + 1 sentinel
 constexpr int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
 
-enum class Player { NONE, BLACK, WHITE };
+enum class Color { NONE, BLACK, WHITE };
+enum class Player { NONE, AI, HUMAN };
 
 struct Direction {
   int dx;
@@ -26,24 +29,28 @@ class Board {
   bool checkWin();
 
   // 状態取得用
-  Player getStoneAt(int x, int y) const;
-  Player getCurrentTurn() const;
+  Color getStoneAt(int x, int y) const;
+  Color getCurrentTurn() const;
+  Player getCurrentPlayer() const;
   int getBlackCaptures() const;
   int getWhiteCaptures() const;
   bool getDoubleThreeStatus() const;
   bool getCapturedStatus() const;
   void setDoubleThreeStatus(bool status);
+  void setupPlayers(TurnOrder order);
 
  private:
   using BoardType = std::bitset<MAX_CELLS>;
 
   BoardType _blackStones;
   BoardType _whiteStones;
-  Player _currentTurn;
+  Color _currentTurn;
   int _blackCaptures;
   int _whiteCaptures;
   bool _doubleThreeStatus;
   bool _capturedStatus;
+
+  std::map<Color, Player> _colorToPlayer;
 
   // 方向定数
   static constexpr int SHIFT_H = 1;                 // 横

--- a/include/Enums.hpp
+++ b/include/Enums.hpp
@@ -3,6 +3,6 @@
 
 enum class AILevel { Easy, Medium, Hard };
 
-enum class TurnOrder { PlayerFirst, AIFirst };
+enum class TurnOrder { HumanFirst, AIFirst };
 
 #endif

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -46,6 +46,8 @@ class GameScene : public Scene {
   std::function<void(const std::string& winner)> _onGameOver;
   sf::Text _countWhiteCaptures;
   sf::Text _countBlackCaptures;
+  sf::Text _turnNotification;
+  float _turnAnimTimer = 0.0f;
 };
 
 #endif

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -39,7 +39,6 @@ class GameScene : public Scene {
   const unsigned int _cellSize = CELL_SIZE;
   sf::Vector2f _boardOffset;
   AILevel _aiLevel;
-  TurnOrder _turnOrder;
 
   Board _board;
   void handleClick(int x, int y);

--- a/include/MenuScene.hpp
+++ b/include/MenuScene.hpp
@@ -34,7 +34,7 @@ class MenuScene : public Scene {
   sf::Text _firstText;
   sf::Text _secondText;
   sf::Text _startButtonText;
-  TurnOrder _turnOrder = TurnOrder::PlayerFirst;
+  TurnOrder _turnOrder = TurnOrder::HumanFirst;
   AILevel _aiLevel = AILevel::Medium;
   std::function<void(TurnOrder turnOrder, AILevel& level)> _onStartGame;
 };

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -5,7 +5,7 @@
 Board::Board()
     : _blackStones(0),
       _whiteStones(0),
-      _currentTurn(Player::BLACK),
+      _currentTurn(Color::BLACK),
       _blackCaptures(0),
       _whiteCaptures(0),
       _doubleThreeStatus(false) {
@@ -26,7 +26,7 @@ bool Board::makeMove(int x, int y) {
       return false;
   }
 
-  if (_currentTurn == Player::BLACK) {
+  if (_currentTurn == Color::BLACK) {
     _blackStones.set(index);
   } else {
     _whiteStones.set(index);
@@ -36,13 +36,13 @@ bool Board::makeMove(int x, int y) {
 }
 
 void Board::changeTurn() {
-  _currentTurn = (_currentTurn == Player::BLACK) ? Player::WHITE : Player::BLACK;
+  _currentTurn = (_currentTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
 }
 
 bool Board::checkWin() {
-  const BoardType& myStones = (_currentTurn == Player::WHITE) ? _whiteStones : _blackStones;
-  const BoardType& oppStones = (_currentTurn == Player::WHITE) ? _blackStones : _whiteStones;
-  int captures = (_currentTurn == Player::WHITE) ? _whiteCaptures : _blackCaptures;
+  const BoardType& myStones = (_currentTurn == Color::WHITE) ? _whiteStones : _blackStones;
+  const BoardType& oppStones = (_currentTurn == Color::WHITE) ? _blackStones : _whiteStones;
+  int captures = (_currentTurn == Color::WHITE) ? _whiteCaptures : _blackCaptures;
 
   // 1. 捕獲勝ち
   if (captures >= 10)
@@ -86,17 +86,25 @@ bool Board::checkWin() {
 
 // --- Getters ---
 
-Player Board::getStoneAt(int x, int y) const {
+Color Board::getStoneAt(int x, int y) const {
   int index = _getIndex(x, y);
   if (_blackStones.test(index))
-    return Player::BLACK;
+    return Color::BLACK;
   if (_whiteStones.test(index))
-    return Player::WHITE;
-  return Player::NONE;
+    return Color::WHITE;
+  return Color::NONE;
 }
 
-Player Board::getCurrentTurn() const {
+Color Board::getCurrentTurn() const {
   return _currentTurn;
+}
+
+Player Board::getCurrentPlayer() const {
+  auto it = this->_colorToPlayer.find(_currentTurn);
+  if (it == this->_colorToPlayer.end()) {
+    return Player::NONE;
+  }
+  return it->second;
 }
 
 int Board::getBlackCaptures() const {
@@ -119,6 +127,17 @@ void Board::setDoubleThreeStatus(bool status) {
   _doubleThreeStatus = status;
 }
 
+void Board::setupPlayers(TurnOrder order) {
+  this->_colorToPlayer.clear();
+  if (order == TurnOrder::AIFirst) {
+    this->_colorToPlayer.insert(std::make_pair(Color::BLACK, Player::AI));
+    this->_colorToPlayer.insert(std::make_pair(Color::WHITE, Player::HUMAN));
+  } else if (order == TurnOrder::HumanFirst) {
+    this->_colorToPlayer.insert(std::make_pair(Color::BLACK, Player::HUMAN));
+    this->_colorToPlayer.insert(std::make_pair(Color::WHITE, Player::AI));
+  }
+}
+
 // --- Private Helpers ---
 
 int Board::_getIndex(int x, int y) const {
@@ -126,9 +145,9 @@ int Board::_getIndex(int x, int y) const {
 }
 
 bool Board::_checkAndProcessCapture(int index) {
-  BoardType& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
-  BoardType& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
-  int& myScore = (_currentTurn == Player::BLACK) ? _blackCaptures : _whiteCaptures;
+  BoardType& myStones = (_currentTurn == Color::BLACK) ? _blackStones : _whiteStones;
+  BoardType& oppStones = (_currentTurn == Color::BLACK) ? _whiteStones : _blackStones;
+  int& myScore = (_currentTurn == Color::BLACK) ? _blackCaptures : _whiteCaptures;
   bool captured = false;
 
   for (int d : ALL_DIRS) {
@@ -158,7 +177,7 @@ bool Board::_checkAndProcessCapture(int index) {
         captured = true;
 
         // TODO: Debug output
-        std::cout << "Capture! Player " << ((_currentTurn == Player::BLACK) ? "BLACK" : "WHITE")
+        std::cout << "Capture! Player " << ((_currentTurn == Color::BLACK) ? "BLACK" : "WHITE")
                   << "\n"
                   << "Total captures - BLACK: " << _blackCaptures << ", WHITE: " << _whiteCaptures
                   << std::endl;
@@ -226,8 +245,8 @@ bool Board::_isStoneCapturable(int index, const BoardType& myStones,
 }
 
 bool Board::_isDoubleThree(int x, int y) {
-  const BoardType& myStones = (_currentTurn == Player::BLACK) ? _blackStones : _whiteStones;
-  const BoardType& oppStones = (_currentTurn == Player::BLACK) ? _whiteStones : _blackStones;
+  const BoardType& myStones = (_currentTurn == Color::BLACK) ? _blackStones : _whiteStones;
+  const BoardType& oppStones = (_currentTurn == Color::BLACK) ? _whiteStones : _blackStones;
 
   int freeThreeCount = 0;
 

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -3,7 +3,8 @@
 GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize)
     : _font(font),
       _countWhiteCaptures(font, "White Captured: 0"),
-      _countBlackCaptures(font, "Black Captured: 0") {
+      _countBlackCaptures(font, "Black Captured: 0"),
+      _turnNotification(font, "Your Turn") {
   this->_countWhiteCaptures.setCharacterSize(Theme::FontSize::Text);
   this->_countWhiteCaptures.setFillColor(Theme::Color::Text);
   this->_countWhiteCaptures.setOrigin(this->_countWhiteCaptures.getGlobalBounds().getCenter());
@@ -11,6 +12,11 @@ GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize)
   this->_countBlackCaptures.setCharacterSize(Theme::FontSize::Text);
   this->_countBlackCaptures.setFillColor(Theme::Color::Text);
   this->_countBlackCaptures.setOrigin(this->_countBlackCaptures.getGlobalBounds().getCenter());
+
+  this->_turnNotification.setCharacterSize(Theme::FontSize::Header);
+  this->_turnNotification.setFillColor(Theme::Color::AlertText);
+  this->_turnNotification.setOrigin(this->_turnNotification.getGlobalBounds().getCenter());
+
   onResize(initalSize);
 }
 
@@ -102,6 +108,10 @@ void GameScene::render(sf::RenderWindow& window) {
   }
   window.draw(this->_countWhiteCaptures);
   window.draw(this->_countBlackCaptures);
+
+  if (_board.getCurrentPlayer() == Player::HUMAN) {
+    window.draw(_turnNotification);
+  }
 }
 
 void GameScene::update(float df) {
@@ -127,6 +137,16 @@ void GameScene::update(float df) {
       ++it;
     }
   }
+  if (_board.getCurrentPlayer() == Player::HUMAN) {
+    _turnAnimTimer += df;
+
+    float sinVal = std::sin(_turnAnimTimer * 5.0f);
+    std::uint8_t alpha = static_cast<std::uint8_t>(190 + 65 * sinVal);
+
+    sf::Color color = _turnNotification.getFillColor();
+    color.a = alpha;
+    _turnNotification.setFillColor(color);
+  }
 }
 
 void GameScene::onResize(const sf::Vector2u& windowSize) {
@@ -144,6 +164,8 @@ void GameScene::onResize(const sf::Vector2u& windowSize) {
 
   this->_countWhiteCaptures.setPosition({w / 4.f, h / 9.5f});
   this->_countBlackCaptures.setPosition({w * 3 / 4.f, h / 9.5f});
+
+  _turnNotification.setPosition({w / 2.f, 50.f});
 }
 
 void GameScene::setOnGameOver(std::function<void(const std::string& winner)> callback) {

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -48,7 +48,7 @@ void GameScene::handleClick(int x, int y) {
       this->_countWhiteCaptures.setString("White Captured: " + std::to_string(whiteCaptures));
       this->_countBlackCaptures.setString("Black Captured: " + std::to_string(blackCaptures));
       if (_board.checkWin()) {
-        std::string winner = _board.getCurrentTurn() == Player::BLACK ? "Black" : "White";
+        std::string winner = _board.getCurrentPlayer() == Player::HUMAN ? "You" : "AI";
         if (_onGameOver)
           _onGameOver(winner);
       }
@@ -85,14 +85,14 @@ void GameScene::render(sf::RenderWindow& window) {
 
   for (unsigned int y = 0; y < _boardSize; ++y) {
     for (unsigned int x = 0; x < _boardSize; ++x) {
-      Player p = _board.getStoneAt(x, y);
+      Color p = _board.getStoneAt(x, y);
 
-      if (p != Player::NONE) {
+      if (p != Color::NONE) {
         float posX = _boardOffset.x + static_cast<float>(x * _cellSize);
         float posY = _boardOffset.y + static_cast<float>(y * _cellSize);
         stone.setPosition(sf::Vector2f(posX, posY));
 
-        stone.setFillColor(p == Player::BLACK ? sf::Color::Black : sf::Color::White);
+        stone.setFillColor(p == Color::BLACK ? sf::Color::Black : sf::Color::White);
         window.draw(stone);
       }
     }
@@ -155,7 +155,7 @@ void GameScene::setAILevel(AILevel& level) {
 }
 
 void GameScene::setTurnOrder(TurnOrder turnOrder) {
-  this->_turnOrder = turnOrder;
+  this->_board.setupPlayers(turnOrder);
 }
 
 GameScene::FloatingMessage::FloatingMessage(const sf::Font& font, const std::string& str,

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -96,7 +96,7 @@ void MenuScene::handleEvents(const EventList& events) {
         }
 
         if (this->_firstButton.getGlobalBounds().contains(mousePos)) {
-          this->_turnOrder = TurnOrder::PlayerFirst;
+          this->_turnOrder = TurnOrder::HumanFirst;
         } else if (this->_secondButton.getGlobalBounds().contains(mousePos)) {
           this->_turnOrder = TurnOrder::AIFirst;
         }
@@ -114,7 +114,7 @@ void MenuScene::handleEvents(const EventList& events) {
 }
 
 void MenuScene::update(float dt) {
-  if (this->_turnOrder == TurnOrder::PlayerFirst) {
+  if (this->_turnOrder == TurnOrder::HumanFirst) {
     this->_firstButton.setFillColor(Theme::Color::ButtonActive);
     this->_secondButton.setFillColor(Theme::Color::ButtonIdle);
   } else {

--- a/src/ResultScene.cpp
+++ b/src/ResultScene.cpp
@@ -97,7 +97,7 @@ void ResultScene::setBackground(const sf::Window& window) {
 }
 
 void ResultScene::setWinner(const std::string& winner) {
-  this->_winnerText.setString("Player " + winner + " wins!");
+  this->_winnerText.setString(winner + " wins!");
   this->_winnerText.setOrigin(_winnerText.getLocalBounds().getCenter());
 }
 


### PR DESCRIPTION
# 概要
人間のターンに画面上に通知を用意しました。
それに伴い先攻後攻の選択もBoardに渡すようにしました。

## 変更点

- Board::PlayerをColorに変更。
- Board::Playerを追加
- BoardにColorとPlayerのマップを追加

## 影響範囲

- Board
- GameScene

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- メニューで先攻を選ぶと黒のターンの時に上に"Your Turn"が表示される
- 後攻を選ぶと白のターンの時に"Your Turn"が表示される
- 勝利時に該当のプレイヤーの"** wins!"が表示される

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
