### PR TITLE
Undo機能の追加

### DIFF
--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -21,6 +21,14 @@ struct Direction {
   int dy;
 };
 
+struct BoardState {
+  BoardType blackStones;
+  BoardType whiteStones;
+  int blackCaptures;
+  int whiteCaptures;
+  Color currentTurn;
+};
+
 class Board {
  public:
   Board();
@@ -44,6 +52,9 @@ class Board {
   void setDoubleThreeStatus(bool status);
   void setupPlayers(TurnOrder order);
 
+  void saveState();
+  bool undo();
+
  private:
   BoardType _blackStones;
   BoardType _whiteStones;
@@ -54,6 +65,7 @@ class Board {
   bool _capturedStatus;
 
   std::map<Color, Player> _colorToPlayer;
+  std::vector<BoardState> _history;
 
   // 方向定数
   static constexpr int SHIFT_H = 1;                 // 横
@@ -76,6 +88,7 @@ class Board {
   bool _checkFreeThree(int x, int y, int dir_x, int dir_y, const BoardType& myStones,
                        const BoardType& oppStones) const;
   bool _isDoubleThree(int x, int y);
+  void _applyState(BoardState state);
 };
 
 #endif

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -61,9 +61,9 @@ class GameScene : public Scene {
   sf::Text _aiInfoText;
   sf::Clock _aiClock;
 
-  sf::RectangleShape _backButton;
-  sf::Text _backText;
-  void _onBack();
+  sf::RectangleShape _undoButton;
+  sf::Text _undoText;
+  void _onUndo();
   void _updateCaptures();
 };
 

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -60,6 +60,11 @@ class GameScene : public Scene {
   void _applyAIMove(Move move);
   sf::Text _aiInfoText;
   sf::Clock _aiClock;
+
+  sf::RectangleShape _backButton;
+  sf::Text _backText;
+  void _onBack();
+  void _updateCaptures();
 };
 
 #endif

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -20,6 +20,7 @@ bool Board::makeMove(int x, int y) {
   if (_blackStones.test(index) || _whiteStones.test(index))
     return false;
 
+  saveState();
   this->_capturedStatus = _checkAndProcessCapture(index);
   if (!_capturedStatus) {
     if (_isDoubleThree(x, y))
@@ -355,4 +356,26 @@ bool Board::_checkFreeThree(int x, int y, int dx, int dy, const BoardType& mySto
   }
 
   return false;
+}
+
+void Board::saveState() {
+  this->_history.push_back(
+      {_blackStones, _whiteStones, _blackCaptures, _whiteCaptures, _currentTurn});
+}
+
+bool Board::undo() {
+  if (_history.empty())
+    return false;
+  BoardState s = this->_history.back();
+  this->_history.pop_back();
+  _applyState(s);
+  return true;
+}
+
+void Board::_applyState(BoardState state) {
+  this->_blackStones = state.blackStones;
+  this->_whiteStones = state.whiteStones;
+  this->_blackCaptures = state.blackCaptures;
+  this->_whiteCaptures = state.whiteCaptures;
+  this->_currentTurn = state.currentTurn;
 }

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -6,7 +6,7 @@ GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize)
       _countBlackCaptures(font, "Black Captured: 0"),
       _turnNotification(font, "Your Turn"),
       _aiInfoText(font, "AI Time: 0.00s"),
-      _backText(font, "Back") {
+      _undoText(font, "Undo") {
   this->_countWhiteCaptures.setCharacterSize(Theme::FontSize::Text);
   this->_countWhiteCaptures.setFillColor(Theme::Color::Text);
   this->_countWhiteCaptures.setOrigin(this->_countWhiteCaptures.getGlobalBounds().getCenter());
@@ -22,13 +22,13 @@ GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize)
   this->_aiInfoText.setCharacterSize(Theme::FontSize::Text);
   this->_aiInfoText.setFillColor(Theme::Color::Text);
 
-  this->_backText.setCharacterSize(Theme::FontSize::Button);
-  this->_backText.setFillColor(sf::Color::Black);
-  this->_backText.setOrigin(_backText.getLocalBounds().getCenter());
+  this->_undoText.setCharacterSize(Theme::FontSize::Button);
+  this->_undoText.setFillColor(sf::Color::Black);
+  this->_undoText.setOrigin(_undoText.getLocalBounds().getCenter());
 
-  this->_backButton.setSize(Theme::Size::Button);
-  this->_backButton.setFillColor(Theme::Color::ButtonActive);
-  this->_backButton.setOrigin(this->_backButton.getSize() / 2.f);
+  this->_undoButton.setSize(Theme::Size::Button);
+  this->_undoButton.setFillColor(Theme::Color::ButtonActive);
+  this->_undoButton.setOrigin(this->_undoButton.getSize() / 2.f);
 
   onResize(initalSize);
 }
@@ -41,8 +41,8 @@ void GameScene::handleEvents(const EventList& events) {
       if (mousePtr->button == sf::Mouse::Button::Left) {
         sf::Vector2f mousePos(static_cast<float>(mousePtr->position.x),
                               static_cast<float>(mousePtr->position.y));
-        if (this->_backButton.getGlobalBounds().contains(mousePos)) {
-          _onBack();
+        if (this->_undoButton.getGlobalBounds().contains(mousePos)) {
+          _onUndo();
         } else
           handleClick(mousePos.x, mousePos.y);
       }
@@ -131,8 +131,8 @@ void GameScene::render(sf::RenderWindow& window) {
 
   window.draw(this->_aiInfoText);
 
-  window.draw(this->_backButton);
-  window.draw(this->_backText);
+  window.draw(this->_undoButton);
+  window.draw(this->_undoText);
 }
 
 void GameScene::update(float df) {
@@ -254,8 +254,8 @@ void GameScene::onResize(const sf::Vector2u& windowSize) {
 
   this->_aiInfoText.setPosition({20.f, h - 50.f});
 
-  this->_backButton.setPosition({w * 3 / 4, h - 50.f});
-  this->_backText.setPosition(_backButton.getPosition());
+  this->_undoButton.setPosition({w * 3 / 4, h - 50.f});
+  this->_undoText.setPosition(_undoButton.getPosition());
 }
 
 void GameScene::setOnGameOver(std::function<void(const std::string& winner)> callback) {
@@ -289,7 +289,7 @@ GameScene::FloatingMessage::FloatingMessage(const sf::Font& font, const std::str
   text.setFillColor(color);
 }
 
-void GameScene::_onBack() {
+void GameScene::_onUndo() {
   if (_isAIThinking)
     return;
 

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -5,7 +5,8 @@ GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize)
       _countWhiteCaptures(font, "White Captured: 0"),
       _countBlackCaptures(font, "Black Captured: 0"),
       _turnNotification(font, "Your Turn"),
-      _aiInfoText(font, "AI Time: 0.00s") {
+      _aiInfoText(font, "AI Time: 0.00s"),
+      _backText(font, "Back") {
   this->_countWhiteCaptures.setCharacterSize(Theme::FontSize::Text);
   this->_countWhiteCaptures.setFillColor(Theme::Color::Text);
   this->_countWhiteCaptures.setOrigin(this->_countWhiteCaptures.getGlobalBounds().getCenter());
@@ -21,6 +22,14 @@ GameScene::GameScene(sf::Font& font, const sf::Vector2u& initalSize)
   this->_aiInfoText.setCharacterSize(Theme::FontSize::Text);
   this->_aiInfoText.setFillColor(Theme::Color::Text);
 
+  this->_backText.setCharacterSize(Theme::FontSize::Button);
+  this->_backText.setFillColor(sf::Color::Black);
+  this->_backText.setOrigin(_backText.getLocalBounds().getCenter());
+
+  this->_backButton.setSize(Theme::Size::Button);
+  this->_backButton.setFillColor(Theme::Color::ButtonActive);
+  this->_backButton.setOrigin(this->_backButton.getSize() / 2.f);
+
   onResize(initalSize);
 }
 
@@ -32,7 +41,10 @@ void GameScene::handleEvents(const EventList& events) {
       if (mousePtr->button == sf::Mouse::Button::Left) {
         sf::Vector2f mousePos(static_cast<float>(mousePtr->position.x),
                               static_cast<float>(mousePtr->position.y));
-        handleClick(mousePos.x, mousePos.y);
+        if (this->_backButton.getGlobalBounds().contains(mousePos)) {
+          _onBack();
+        } else
+          handleClick(mousePos.x, mousePos.y);
       }
     }
   }
@@ -55,10 +67,9 @@ void GameScene::handleClick(int x, int y) {
       if (_board.getCapturedStatus()) {
         displayTimedMessage("Capture", {posX, posY});
       }
-      int whiteCaptures = this->_board.getWhiteCaptures();
-      int blackCaptures = this->_board.getBlackCaptures();
-      this->_countWhiteCaptures.setString("White Captured: " + std::to_string(whiteCaptures));
-      this->_countBlackCaptures.setString("Black Captured: " + std::to_string(blackCaptures));
+
+      _updateCaptures();
+
       if (_board.checkWin()) {
         if (_onGameOver)
           _onGameOver("You");
@@ -119,6 +130,9 @@ void GameScene::render(sf::RenderWindow& window) {
   }
 
   window.draw(this->_aiInfoText);
+
+  window.draw(this->_backButton);
+  window.draw(this->_backText);
 }
 
 void GameScene::update(float df) {
@@ -239,6 +253,9 @@ void GameScene::onResize(const sf::Vector2u& windowSize) {
   this->_turnNotification.setPosition({w / 2.f, 50.f});
 
   this->_aiInfoText.setPosition({20.f, h - 50.f});
+
+  this->_backButton.setPosition({w * 3 / 4, h - 50.f});
+  this->_backText.setPosition(_backButton.getPosition());
 }
 
 void GameScene::setOnGameOver(std::function<void(const std::string& winner)> callback) {
@@ -270,4 +287,22 @@ GameScene::FloatingMessage::FloatingMessage(const sf::Font& font, const std::str
   sf::Color color = text.getFillColor();
   color.a = 255;
   text.setFillColor(color);
+}
+
+void GameScene::_onBack() {
+  if (_isAIThinking)
+    return;
+
+  if (this->_board.undo()) {
+    this->_board.undo();
+  }
+
+  _updateCaptures();
+}
+
+void GameScene::_updateCaptures() {
+  int whiteCaptures = this->_board.getWhiteCaptures();
+  int blackCaptures = this->_board.getBlackCaptures();
+  this->_countWhiteCaptures.setString("White Captured: " + std::to_string(whiteCaptures));
+  this->_countBlackCaptures.setString("Black Captured: " + std::to_string(blackCaptures));
 }


### PR DESCRIPTION
# 概要
プレイヤーがゲームを巻き戻せるようにしました。

## 変更点

- Boardでボードの状態をvectorで管理
- GameSceneでUndoボタンが押された時に履歴を戻る


## 影響範囲

- GameScene
- Board

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- Undoボタンを押すと直前の自分のターンまで戻る
- Captureをやり直した時に画面上の捕獲数の文字が更新されて元にもどってること

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
