### PR TITLE
SIGINTで終了した時にメモリリークしていたのでハンドラーを追加

### DIFF
--- a/include/Enums.hpp
+++ b/include/Enums.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-enum class AILevel { Easy, Medium, Hard };
+enum class AILevel { Easy, Normal, Hard };
 
 enum class TurnOrder { HumanFirst, AIFirst };
 

--- a/include/Gomoku.hpp
+++ b/include/Gomoku.hpp
@@ -5,6 +5,7 @@
 #include <ResultScene.hpp>
 #include <SFML/Graphics.hpp>
 #include <Scene.hpp>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <iostream>
@@ -19,8 +20,10 @@ class Gomoku {
   Gomoku();
 
   void run();
+  void stop();
 
  private:
+  std::atomic<bool> _isRunning;
   sf::RenderWindow _window;
   std::unique_ptr<MenuScene> _menuScene;
   std::unique_ptr<GameScene> _gameScene;

--- a/include/MenuScene.hpp
+++ b/include/MenuScene.hpp
@@ -25,17 +25,17 @@ class MenuScene : public Scene {
   sf::RectangleShape _firstButton;
   sf::RectangleShape _secondButton;
   sf::RectangleShape _easyButton;
-  sf::RectangleShape _mediumButton;
+  sf::RectangleShape _normalButton;
   sf::RectangleShape _hardButton;
   sf::Text _levelText;
-  sf::Text _mediumText;
+  sf::Text _normalText;
   sf::Text _easyText;
   sf::Text _hardText;
   sf::Text _firstText;
   sf::Text _secondText;
   sf::Text _startButtonText;
   TurnOrder _turnOrder = TurnOrder::HumanFirst;
-  AILevel _aiLevel = AILevel::Medium;
+  AILevel _aiLevel = AILevel::Normal;
   std::function<void(TurnOrder& turnOrder, AILevel& level, OpeningRule& rule)> _onStartGame;
 
   OpeningRule _openingRule = OpeningRule::Standard;

--- a/src/AI.cpp
+++ b/src/AI.cpp
@@ -443,7 +443,7 @@ int AI::_getDepthFromLevel(AILevel level) {
   switch (level) {
     case AILevel::Easy:
       return DEPTH_EASY;
-    case AILevel::Medium:
+    case AILevel::Normal:
       return DEPTH_NORMAL;
     case AILevel::Hard:
       return DEPTH_HARD;

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -2,6 +2,7 @@
 
 Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
   _initFont("arial.ttf");
+  this->_isRunning = true;
   this->_window.setMinimumSize(sf::Vector2u(1080, 1000));
 
   this->_menuScene = std::make_unique<MenuScene>(font, this->_window.getSize());

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -2,6 +2,7 @@
 
 Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
   initFont("arial.ttf");
+  this->_isRunning = true;
   this->_window.setMinimumSize(sf::Vector2u(1080, 1000));
 
   this->_menuScene = std::make_unique<MenuScene>(font, this->_window.getSize());
@@ -35,7 +36,7 @@ void Gomoku::initOnGameOver(const std::string& winner) {
 
 void Gomoku::run() {
   sf::Clock clock;
-  while (this->_window.isOpen()) {
+  while (this->_window.isOpen() && this->_isRunning) {
     sf::Time dt = clock.restart();
     float deltaTime = dt.asSeconds();
     EventList events = getEventList();
@@ -45,6 +46,10 @@ void Gomoku::run() {
     this->_currentScene->render(this->_window);
     this->_window.display();
   }
+}
+
+void Gomoku::stop() {
+  this->_isRunning = false;
 }
 
 void Gomoku::initFont(const std::string font) {

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -8,7 +8,7 @@ MenuScene::MenuScene(sf::Font& font, const sf::Vector2u& initalSize)
       _firstText(font, "Go first"),
       _secondText(font, "Go second"),
       _easyText(font, "Easy"),
-      _mediumText(font, "Medium"),
+      _normalText(font, "Normal"),
       _hardText(font, "Hard"),
       _levelText(font, "Select the AI level."),
       _openingRuleText(font, "Select starting condition."),
@@ -62,14 +62,14 @@ MenuScene::MenuScene(sf::Font& font, const sf::Vector2u& initalSize)
   this->_easyText.setStyle(sf::Text::Bold);
   this->_easyText.setOrigin(_easyText.getLocalBounds().getCenter());
 
-  this->_mediumButton.setSize(Theme::Size::Button);
-  this->_mediumButton.setFillColor(Theme::Color::ButtonIdle);
-  this->_mediumButton.setOrigin(this->_mediumButton.getSize() / 2.f);
+  this->_normalButton.setSize(Theme::Size::Button);
+  this->_normalButton.setFillColor(Theme::Color::ButtonIdle);
+  this->_normalButton.setOrigin(this->_normalButton.getSize() / 2.f);
 
-  this->_mediumText.setCharacterSize(Theme::FontSize::Button);
-  this->_mediumText.setFillColor(sf::Color::Black);
-  this->_mediumText.setStyle(sf::Text::Bold);
-  this->_mediumText.setOrigin(_mediumText.getLocalBounds().getCenter());
+  this->_normalText.setCharacterSize(Theme::FontSize::Button);
+  this->_normalText.setFillColor(sf::Color::Black);
+  this->_normalText.setStyle(sf::Text::Bold);
+  this->_normalText.setOrigin(_normalText.getLocalBounds().getCenter());
 
   this->_hardButton.setSize(Theme::Size::Button);
   this->_hardButton.setFillColor(Theme::Color::ButtonIdle);
@@ -139,8 +139,8 @@ void MenuScene::handleEvents(const EventList& events) {
 
         if (this->_easyButton.getGlobalBounds().contains(mousePos)) {
           this->_aiLevel = AILevel::Easy;
-        } else if (this->_mediumButton.getGlobalBounds().contains(mousePos)) {
-          this->_aiLevel = AILevel::Medium;
+        } else if (this->_normalButton.getGlobalBounds().contains(mousePos)) {
+          this->_aiLevel = AILevel::Normal;
         } else if (this->_hardButton.getGlobalBounds().contains(mousePos)) {
           this->_aiLevel = AILevel::Hard;
         }
@@ -162,7 +162,7 @@ void MenuScene::update(float dt) {
   _updateButtonStatus(this->_secondButton, _turnOrder == TurnOrder::AIFirst);
 
   _updateButtonStatus(this->_easyButton, _aiLevel == AILevel::Easy);
-  _updateButtonStatus(this->_mediumButton, _aiLevel == AILevel::Medium);
+  _updateButtonStatus(this->_normalButton, _aiLevel == AILevel::Normal);
   _updateButtonStatus(this->_hardButton, _aiLevel == AILevel::Hard);
 
   _updateButtonStatus(this->_standardButton, _openingRule == OpeningRule::Standard);
@@ -187,8 +187,8 @@ void MenuScene::render(sf::RenderWindow& window) {
   window.draw(this->_levelText);
   window.draw(this->_easyButton);
   window.draw(this->_easyText);
-  window.draw(this->_mediumButton);
-  window.draw(this->_mediumText);
+  window.draw(this->_normalButton);
+  window.draw(this->_normalText);
   window.draw(this->_hardButton);
   window.draw(this->_hardText);
   window.draw(this->_openingRuleText);
@@ -218,11 +218,11 @@ void MenuScene::onResize(const sf::Vector2u& windowSize) {
   this->_levelText.setPosition({w / 2.f, _secondButton.getPosition().y + 80});
   this->_easyButton.setPosition({w / 4.f, _levelText.getPosition().y + 50});
   this->_easyText.setPosition(_easyButton.getPosition());
-  this->_mediumButton.setPosition({w / 2.f, _levelText.getPosition().y + 50});
-  this->_mediumText.setPosition(_mediumButton.getPosition());
+  this->_normalButton.setPosition({w / 2.f, _levelText.getPosition().y + 50});
+  this->_normalText.setPosition(_normalButton.getPosition());
   this->_hardButton.setPosition({(w / 4.f) * 3.f, _levelText.getPosition().y + 50});
   this->_hardText.setPosition(_hardButton.getPosition());
-  this->_openingRuleText.setPosition({w / 2.f, _mediumButton.getPosition().y + 80});
+  this->_openingRuleText.setPosition({w / 2.f, _normalButton.getPosition().y + 80});
   this->_standardButton.setPosition({w / 4.f, _openingRuleText.getPosition().y + 50});
   this->_standardText.setPosition(_standardButton.getPosition());
   this->_proButton.setPosition({w / 2.f, _openingRuleText.getPosition().y + 50});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,13 +2,22 @@
 #include <SFML/Graphics.hpp>
 #include <chrono>
 #include <cmath>
+#include <csignal>
 #include <iostream>
 #include <optional>
 #include <string>
 #include <vector>
 
+Gomoku* g_pointer = nullptr;
+
+void signalHandler(int sig) {
+  g_pointer->stop();
+}
+
 int main() {
   Gomoku game;
+  g_pointer = &game;
+  std::signal(SIGINT, signalHandler);
   game.run();
   return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,5 +19,6 @@ int main() {
   g_pointer = &game;
   std::signal(SIGINT, signalHandler);
   game.run();
+  std::cout << "Gomoku was Terminated." << std::endl;
   return 0;
 }


### PR DESCRIPTION
# 概要
Gomoku::runが動いてる時にSIGINTが入力されるとメモリリークが起きていたので、シグナルハンドラーを追加しました。
フロントのAIのレベルをバックに合わせてMediumからNormalに変更しました。

## 変更点

- Gomoku::_isRunning,stop()を追加
- main.cppにシグナルハンドラーを追加
- AIのレベルをMediumからNormalに変更


## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- SIGINTを送って標準出力にGomoku was Terminated.が表示されること
- テストケース2
- テストケース3

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
