### PR TITLE
AI探索の高速化とロジック改善：履歴処理の軽量化と反復深化の実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ SRC_FILES          = main.cpp \
 					 AI.cpp \
 					 Evaluator.cpp \
 					 TranspositionTable.cpp \
+					 Zobrist.cpp \
 
 IFLAGS            += -Iinclude
 SRCS               = $(addprefix $(SRC_DIR), $(SRC_FILES))

--- a/include/AI.hpp
+++ b/include/AI.hpp
@@ -34,11 +34,12 @@ class AI {
 
  private:
   // --- Configuration ---
-  static constexpr int DEPTH_EASY = 5;
-  static constexpr int DEPTH_NORMAL = 10;
-  static constexpr int DEPTH_HARD = 20;
+  static constexpr int DEPTH_EASY = 2;
+  static constexpr int DEPTH_NORMAL = 5;
+  static constexpr int DEPTH_HARD = 10;
 
-  static constexpr int MAX_MOVES_TO_CONSIDER = 10;
+  static constexpr int MAX_MOVES_TO_CONSIDER = 14;
+  static constexpr int SEARCH_WIDTH = 3;
 
   // --- Component State ---
   Color _aiPlayer;
@@ -66,7 +67,8 @@ class AI {
    * @param board The current board state.
    * @return A vector of possible moves with heuristic scores. (MAX: MAX_MOVES_TO_CONSIDER)
    */
-  std::vector<Move> _generateMoves(const Board& board, int depth);
+  std::vector<Move> _generateMoves(const Board& board, int depth,
+                                   size_t limit = MAX_MOVES_TO_CONSIDER);
 
   std::vector<Move> _randomNeighbor(const BoardType& occupied);
 

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -221,6 +221,7 @@ class Board {
   // Board Data
   BoardType _blackStones;
   BoardType _whiteStones;
+  BoardType _sentinelStones;  // Padding walls to simplify boundary checks
 
   // Game State
   Color _currentTurn;

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -38,6 +38,18 @@ struct BoardState {
   uint64_t hash;
 };
 
+// Information about a move, including captures
+struct AIMoveRecord {
+  int moveIndex;          // 打った手
+  uint64_t prevHash;      // 手を打つ前のハッシュ値
+  int prevBlackCaptures;  // 手を打つ前の黒の捕獲数
+  int prevWhiteCaptures;  // 手を打つ前の白の捕獲数
+
+  // 捕獲された石のインデックスを記録（最大でも8個程度なので固定長で十分）
+  int capturedCount;
+  std::array<int, 8> capturedIndices;
+};
+
 // ==========================================
 // Board Class
 // ==========================================
@@ -68,6 +80,8 @@ class Board {
    */
   bool makeMove(int index);
 
+  bool makeMoveAI(int index);
+
   /**
    * Switches the current turn to the other player.
    */
@@ -83,6 +97,8 @@ class Board {
    * @return true if undo was successful (history not empty).
    */
   bool undo();
+
+  void undoAI();
 
   // ----------------------------------------------------------------
   // Game Status & Win Conditions
@@ -170,8 +186,9 @@ class Board {
    * Updates capture counts and removes stones from bit boards.
    * Updates the _capturedStatus flag.
    * @param index The index of the newly placed stone.
+   * @param record Optional AIMoveRecord to log captured stones. if nullptr, no logging is done.
    */
-  void _processCapture(int index);
+  void _processCapture(int index, AIMoveRecord* record);
 
   /**
    * Checks if the move at (x, y) creates a forbidden "Double Three".
@@ -237,7 +254,8 @@ class Board {
 
   // Meta Data
   std::map<Color, Player> _colorToPlayer;
-  std::vector<BoardState> _history;  // For undo functionality
+  std::vector<BoardState> _history;      // For undo functionality
+  std::vector<AIMoveRecord> _aiHistory;  // For AI move tracking
 
   // Hashing
   uint64_t _currentHash;

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <iostream>
 #include <map>
 #include <vector>
 
@@ -33,6 +34,7 @@ struct BoardState {
   int blackCaptures;
   int whiteCaptures;
   Color currentTurn;
+  Color nextTurn;
   uint64_t hash;
 };
 
@@ -222,6 +224,7 @@ class Board {
 
   // Game State
   Color _currentTurn;
+  Color _nextTurn;
   int8_t _blackCaptures;
   int8_t _whiteCaptures;
 
@@ -231,7 +234,7 @@ class Board {
 
   // Meta Data
   std::map<Color, Player> _colorToPlayer;
-  std::vector<BoardState> _history;  // Stack for undo functionality
+  std::vector<BoardState> _history;  // For undo functionality
 
   // Hashing
   uint64_t _currentHash;

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -44,6 +44,7 @@ struct AIMoveRecord {
   uint64_t prevHash;      // 手を打つ前のハッシュ値
   int prevBlackCaptures;  // 手を打つ前の黒の捕獲数
   int prevWhiteCaptures;  // 手を打つ前の白の捕獲数
+  Color currentTurn;
 
   // 捕獲された石のインデックスを記録（最大でも8個程度なので固定長で十分）
   int capturedCount;

--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <iostream>
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "Enums.hpp"
@@ -34,7 +35,6 @@ struct BoardState {
   int blackCaptures;
   int whiteCaptures;
   Color currentTurn;
-  Color nextTurn;
   uint64_t hash;
 };
 
@@ -62,12 +62,11 @@ class Board {
   /**
    * Attempts to place a stone at (x, y).
    * Handles rule validation, capture processing, and state updates.
-   * @param x The x-coordinate (0-based).
-   * @param y The y-coordinate (0-based).
+   * @param index The linear index of the move.
    * @return true if the move was valid and executed.
    *         false if the move was invalid (out of bounds, occupied, double three).
    */
-  bool makeMove(int x, int y);
+  bool makeMove(int index);
 
   /**
    * Switches the current turn to the other player.
@@ -115,6 +114,7 @@ class Board {
   const BoardType& getWhiteStones() const;
   const BoardType& getMyStones(Color myColor) const;
   const BoardType& getOppStones(Color myColor) const;
+  const BoardType& getSentinelStones() const;
 
   // -- Computed Bitsets --
   BoardType getEmptyStones() const;
@@ -122,6 +122,7 @@ class Board {
 
   // -- Game State --
   Color getCurrentTurn() const;
+  Color getNextTurn() const;
   Player getCurrentPlayer() const;
   int getBlackCaptures() const;
   int getWhiteCaptures() const;
@@ -133,6 +134,10 @@ class Board {
 
   // -- Hashing --
   uint64_t getHash() const;
+
+  // -- Helpers --
+  std::pair<int, int> getCoordinates(int index) const;
+  int getIndex(int x, int y) const;
 
   // -- AI Helpers --
   /**
@@ -156,7 +161,6 @@ class Board {
   void _applyState(const BoardState& state);
 
   // -- Coordinate / Bit Utils --
-  int _getIndex(int x, int y) const;
   int8_t _getCaptureCount(Color color) const;
 
   // -- Rule Implementations --
@@ -173,11 +177,10 @@ class Board {
    * Checks if the move at (x, y) creates a forbidden "Double Three".
    * A double-three is two simultaneous "open threes".
    * Updates the _doubleThreeStatus flag.
-   * @param x The x-coordinate of the move.
-   * @param y The y-coordinate of the move.
+   * @param index The index of the newly placed stone.
    * @return true if the move creates a double three.
    */
-  void _DoubleThree(int x, int y);
+  void _DoubleThree(int index);
 
   /**
    * Retrieves a 11-bit representation of stones along a line centered at (x, y).
@@ -185,7 +188,7 @@ class Board {
    * @param dir The direction to extract the line.
    * @return LineBits containing my and opponent stones along the line.
    */
-  LineBits _getLineBits(int x, int y, const Direction dir, const BoardType& myStones,
+  LineBits _getLineBits(int centerIndex, int offset, const BoardType& myStones,
                         const BoardType& oppStones) const;
 
   /**
@@ -225,7 +228,6 @@ class Board {
 
   // Game State
   Color _currentTurn;
-  Color _nextTurn;
   int8_t _blackCaptures;
   int8_t _whiteCaptures;
 
@@ -243,22 +245,5 @@ class Board {
   // ----------------------------------------------------------------
   // Directional Constants
   // ----------------------------------------------------------------
-
-  // Bitshift offsets for the 1D bitset (optimized for performance)
-  static constexpr int SHIFT_H = 1;                 // Horizontal
-  static constexpr int SHIFT_V = BOARD_WIDTH;       // Vertical
-  static constexpr int SHIFT_D1 = BOARD_WIDTH + 1;  // Diagonal (Top-Left to Bottom-Right)
-  static constexpr int SHIFT_D2 = BOARD_WIDTH - 1;  // Diagonal (Top-Right to Bottom-Left)
-
-  static constexpr std::array<int, 4> ALL_SHIFTS = {SHIFT_H, SHIFT_V, SHIFT_D1, SHIFT_D2};
-
-  // Coordinate deltas for 2D logic (e.g., checking surroundings)
-  static constexpr std::array<Direction, 4> CHECK_DIRS = {{
-      {1, 0},  // Horizontal
-      {0, 1},  // Vertical
-      {1, 1},  // Diagonal Down-Right
-      {-1, 1}  // Diagonal Down-Left
-  }};
-
   static const BoardType _validMask;
 };

--- a/include/Evaluator.hpp
+++ b/include/Evaluator.hpp
@@ -66,7 +66,7 @@ class Evaluator {
    * This is fast and approximate. Used for sorting moves (Move Ordering).
    * @return Raw priority score.
    */
-  static int evaluateMovePriority(const Board& board, int x, int y, Color color);
+  static int evaluateMovePriority(const Board& board, int index, Color color);
 
  private:
   // --- Helper Constants ---
@@ -80,8 +80,8 @@ class Evaluator {
   // --- Internal Logic ---
 
   // Check line score based on coordinates (for Move Ordering)
-  static int _CheckLineScore(const Board& board, int x, int y, int dx, int dy, Color myColor,
-                             Color oppColor);
+  static int _CheckLineScore(int index, int offset, const BoardType& myStones,
+                             const BoardType& oppStones, const BoardType& sentinels);
 
   // Evaluate score for a single color (used in full evaluation)
   static int _evaluateColor(const BoardType& stones, const BoardType& empty);

--- a/include/GameConfig.hpp
+++ b/include/GameConfig.hpp
@@ -3,7 +3,7 @@
 #include <bitset>
 
 constexpr int BOARD_SIZE = 19;
-constexpr int BOARD_WIDTH = 32;
+constexpr int BOARD_WIDTH = 32;  // 19 + sentinel padding
 constexpr int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
 
 // ==========================================

--- a/include/GameConfig.hpp
+++ b/include/GameConfig.hpp
@@ -1,30 +1,40 @@
 #pragma once
 
+#include <array>
 #include <bitset>
 
+// 基本定数
 constexpr int BOARD_SIZE = 19;
 constexpr int BOARD_WIDTH = 32;  // 19 + sentinel padding
 constexpr int MAX_CELLS = BOARD_WIDTH * BOARD_SIZE;
+constexpr int CENTER_INDEX = (BOARD_SIZE / 2) * BOARD_WIDTH + (BOARD_SIZE / 2);
+
+// ビット演算用
+constexpr int WIDTH_SHIFT = 5;
+constexpr int WIDTH_MASK = 31;  // 0x1F
+
+// 重要: ここで1回だけ定義する（Single Source of Truth）
+// AI, Board, Evaluator すべてがこれを使う
+constexpr std::array<int, 4> DIR_OFFSETS = {
+    1,                // Horizontal
+    BOARD_WIDTH,      // Vertical
+    BOARD_WIDTH + 1,  // Diagonal (Top-Left to Bottom-Right)
+    BOARD_WIDTH - 1   // Diagonal (Top-Right to Bottom-Left)
+};
 
 // ==========================================
 // Move Structure
 // ==========================================
-
 struct Move {
-  int x;
-  int y;
+  int index;
   int score;
 
-  // Operator for sorting moves (descending order of score).
-  // Crucial for Move Ordering in Alpha-Beta pruning.
   bool operator>(const Move& other) const {
     return score > other.score;
   }
-
   bool operator==(const Move& other) const {
-    return x == other.x && y == other.y;
+    return index == other.index;
   }
 };
 
-// Type alias for the bit board representation
 using BoardType = std::bitset<MAX_CELLS>;

--- a/include/GameScene.hpp
+++ b/include/GameScene.hpp
@@ -50,8 +50,9 @@ class GameScene : public Scene {
   const unsigned int _cellSize = CELL_SIZE;
   sf::Vector2f _boardOffset;
   AILevel _aiLevel;
-
   Board _board;
+  AI _ai;
+
   void handleClick(int x, int y);
   void displayTimedMessage(const std::string& message, sf::Vector2f pos);
   void _handleMessage(float df);

--- a/include/Zobrist.hpp
+++ b/include/Zobrist.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <random>
 
@@ -9,30 +8,17 @@
 
 class Zobrist {
  public:
-  // Initialize the Zobrist tables with random values once
-  static void initialize() {
-    std::mt19937_64 rng(12345);  // Fixed seed for reproducibility
-    std::uniform_int_distribution<uint64_t> dist;
+  // 乱数テーブルの初期化
+  static void initialize();
 
-    for (int i = 0; i < MAX_CELLS; ++i) {
-      table[i][0] = dist(rng);  // Black
-      table[i][1] = dist(rng);  // White
-    }
-    blackTurn = dist(rng);
-  }
+  // 指定したインデックスと色のハッシュ値を取得
+  static uint64_t getPieceHash(int index, Color color);
 
-  // Get the random bitstring for a specific position and color
-  // colorIndex: 0 for Black, 1 for White
-  static uint64_t getPieceHash(int index, Color color) {
-    return table[index][(color == Color::BLACK) ? 0 : 1];
-  }
-
-  static uint64_t getBlackTurnHash() {
-    return blackTurn;
-  }
+  // 黒番の手番ハッシュ値を取得
+  static uint64_t getBlackTurnHash();
 
  private:
-  // [Position][Color]
-  static inline uint64_t table[MAX_CELLS][2];
-  static inline uint64_t blackTurn;
+  // 静的メンバ変数の宣言（実体はcppファイルへ）
+  static uint64_t table[MAX_CELLS][2];
+  static uint64_t blackTurn;
 };

--- a/src/AI.cpp
+++ b/src/AI.cpp
@@ -5,33 +5,6 @@
 AI::AI() : _tt(20) {
 }
 
-// TODO: debug
-// 現在の盤面から、TTを辿ってAIが考えている最善手順を表示する
-void AI::printPV(Board board) {
-  std::cout << "PV: ";
-  for (int i = 0; i < 20; ++i) {
-    uint64_t key = board.getHash();
-    TTEntry* entry = _tt.get(key);
-
-    // エントリがない、または最善手が記録されていないなら終了
-    if (entry == nullptr || entry->bestMove.x == -1) {
-      break;
-    }
-
-    Move m = entry->bestMove;
-    std::cout << "(" << m.x << "," << m.y << ") -> ";
-
-    if (!board.makeMove(m.x, m.y))
-      break;
-    if (board.checkWin()) {
-      std::cout << "WIN";
-      break;
-    }
-    board.changeTurn();
-  }
-  std::cout << std::endl;
-}
-
 Move AI::getBestMove(const Board& board, Color color, AILevel level,
                      std::atomic<bool>& cancelFlag) {
   _aiPlayer = color;
@@ -40,7 +13,7 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
   int targetDepth = _getDepthFromLevel(level);
 
   // Prepare variables for Iterative Deepening
-  Move globalBestMove = {-1, -1, 0};
+  Move globalBestMove = {-1, 0};
 
   // Clone the board ONCE for the search process
   Board searchBoard = board;
@@ -57,7 +30,7 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
     std::vector<Move> moves = _generateMoves(searchBoard, depth);
 
     if (moves.empty())
-      return {-1, -1, 0};
+      return {-1, 0};
     if (moves.size() == 1)
       return moves[0];  // Optimization
 
@@ -65,10 +38,10 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
     uint64_t rootHash = searchBoard.getHash();
     TTEntry* entry = _tt.get(rootHash);
 
-    if (entry != nullptr && entry->bestMove.x != -1) {
+    if (entry != nullptr && entry->bestMove.index != -1) {
       // Move the best move from previous depth to the front
       for (size_t i = 0; i < moves.size(); ++i) {
-        if (moves[i].x == entry->bestMove.x && moves[i].y == entry->bestMove.y) {
+        if (moves[i].index == entry->bestMove.index) {
           std::swap(moves[0], moves[i]);
           break;
         }
@@ -83,7 +56,7 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
     int beta = std::numeric_limits<int>::max();
 
     for (const Move& m : moves) {
-      if (!searchBoard.makeMove(m.x, m.y))
+      if (!searchBoard.makeMove(m.index))
         continue;
 
       // Win check optimization
@@ -92,7 +65,6 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
         // Found a winning move at this depth.
         // Store and return immediately (no need to search deeper)
         _tt.store(rootHash, depth, ScoreConfig::WIN, TTFlag::EXACT, m);
-        printPV(board);
         return m;
       }
 
@@ -129,21 +101,14 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
     TTFlag flag =
         TTFlag::EXACT;  // Root node is usually exact unless alpha/beta cut logic is complex
     _tt.store(rootHash, depth, globalBestMove.score, flag, globalBestMove);
-
-    // Debug output for each depth (Optional)
-    // std::cout << "Depth " << depth << " done. Best: " << globalBestMove.x << "," <<
-    // globalBestMove.y << std::endl;
   }
-
-  // Print PV using the original board (hash matches rootHash)
-  printPV(board);
 
   return globalBestMove;
 }
 
 int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPlayer,
                  std::atomic<bool>& cancelFlag) {
-  // [1] TT Lookup (既存コード) ...
+  // [1] TT Lookup
   uint64_t key = board.getHash();
   TTEntry* ttEntry = _tt.get(key);
   if (ttEntry != nullptr && ttEntry->depth >= depth) {
@@ -160,20 +125,21 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
   if (cancelFlag.load()) {
     return 0;
   }
-  // [2] Base Case (既存コード) ...
+
+  // [2] Base Case
   if (depth == 0)
     return Evaluator::evaluate(board, _aiPlayer);
 
-  // [3] Move Generation (depthを渡すよう変更済み)
+  // [3] Move Generation
   std::vector<Move> moves = _generateMoves(board, depth);
   if (moves.empty())
     return 0;
 
-  // TT Move Ordering (既存コード) ...
-  if (ttEntry != nullptr && ttEntry->bestMove.x != -1) {
+  // TT Move Ordering
+  if (ttEntry != nullptr && ttEntry->bestMove.index != -1) {
     // 先頭へスワップ
     for (size_t i = 0; i < moves.size(); ++i) {
-      if (moves[i].x == ttEntry->bestMove.x && moves[i].y == ttEntry->bestMove.y) {
+      if (moves[i].index == ttEntry->bestMove.index) {
         std::swap(moves[0], moves[i]);
         break;
       }
@@ -183,14 +149,14 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
   // --- PVS Search Loop ---
 
   int originalAlpha = alpha;
-  Move bestMoveInThisNode = {-1, -1, 0};
+  Move bestMoveInThisNode = {-1, 0};
   bool isFirstMove = true;  // ★ PVS用のフラグ
 
   if (maximizingPlayer) {
     int maxEval = std::numeric_limits<int>::min();
 
     for (const Move& m : moves) {
-      if (!board.makeMove(m.x, m.y))
+      if (!board.makeMove(m.index))
         continue;
 
       // 即時勝利判定
@@ -233,7 +199,7 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
       // Beta Cut-off
       if (beta <= alpha) {
         // ★ Killer Heuristic (Maximizerにとって、相手のこの分岐を断ち切る強い手)
-        if (!(_killerMoves[depth][0].x == m.x && _killerMoves[depth][0].y == m.y)) {
+        if (_killerMoves[depth][0].index != m.index) {
           _killerMoves[depth][1] = _killerMoves[depth][0];
           _killerMoves[depth][0] = m;
         }
@@ -241,7 +207,8 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
       }
       isFirstMove = false;  // 2周目からはfalse
     }
-    // 結果保存 (既存コード)
+
+    // 結果保存
     TTFlag flag = (maxEval <= originalAlpha)
                       ? TTFlag::UPPERBOUND
                       : (maxEval >= beta ? TTFlag::LOWERBOUND : TTFlag::EXACT);
@@ -253,7 +220,7 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
     int minEval = std::numeric_limits<int>::max();
 
     for (const Move& m : moves) {
-      if (!board.makeMove(m.x, m.y))
+      if (!board.makeMove(m.index))
         continue;
 
       if (board.checkWin()) {
@@ -295,7 +262,7 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
       if (beta <= alpha) {
         // ★ Killer Heuristic (Minimizer分岐でのCut。必要ならここでも更新可)
         // 一般的にはMinimizer側でも有効な防御手などを登録する価値があります
-        if (!(_killerMoves[depth][0].x == m.x && _killerMoves[depth][0].y == m.y)) {
+        if (_killerMoves[depth][0].index != m.index) {
           _killerMoves[depth][1] = _killerMoves[depth][0];
           _killerMoves[depth][0] = m;
         }
@@ -321,7 +288,7 @@ std::vector<Move> AI::_generateMoves(const Board& board, int depth) {
   // 1. First Move Strategy (Center)
   // If the board is empty, always play the center (standard Gomoku strategy).
   if (occupied.none()) {
-    moves.push_back({BOARD_SIZE / 2, BOARD_SIZE / 2, 0});
+    moves.push_back({CENTER_INDEX, 0});
     return moves;
   }
 
@@ -353,25 +320,21 @@ std::vector<Move> AI::_generateMoves(const Board& board, int depth) {
   // 3. Evaluate and Collect Candidates
   for (int i = 0; i < MAX_CELLS; ++i) {
     if (candidates.test(i)) {
-      int x = i % BOARD_WIDTH;
-      int y = i / BOARD_WIDTH;
+      int priority = Evaluator::evaluateMovePriority(board, i, board.getCurrentTurn());
 
-      // Note: Since getEmptyStones() masks out the padding,
-      // x will never be >= BOARD_SIZE. But a safety check is fine.
-
-      // Calculate heuristic score for sorting
-      // (This function must be lightweight!)
-      int priority = Evaluator::evaluateMovePriority(board, x, y, board.getCurrentTurn());
+      // Killer Move Logic
+      // 以前のコードでは moves[i] と比較していましたが、
+      // ここでは「現在の候補地 i」と「キラー手の位置」を比較します
 
       // ★追加: キラー手ならボーナスを与える
       // (現在の深さがわからないので、引数に depth を渡すように変更する必要があります)
       // ここでは簡易的に「_generateMovesにdepthを渡す」修正が必要です。
-      if (moves[i] == _killerMoves[depth][0])
-        priority += 100000;  // Winよりは低いが非常に高く
-      else if (moves[i] == _killerMoves[depth][1])
+      if (i == _killerMoves[depth][0].index)
+        priority += 100000;
+      else if (i == _killerMoves[depth][1].index)
         priority += 90000;
 
-      moves.push_back({x, y, priority});
+      moves.push_back({i, priority});
     }
   }
 
@@ -395,48 +358,76 @@ std::vector<Move> AI::_generateMoves(const Board& board, int depth) {
   return moves;
 }
 
-// return: 1 size list of random neighboring moves
 std::vector<Move> AI::_randomNeighbor(const BoardType& occupied) {
   std::vector<Move> moves;
   moves.reserve(1);
 
-  // Find all occupied positions
-  std::vector<int> occupiedIndices;
+  // 1. Find the occupied stone
+  // count() == 1 の前提で呼び出されるため、最初のビットが見つかればOKです
+  int baseIndex = -1;
   for (int i = 0; i < MAX_CELLS; ++i) {
     if (occupied.test(i)) {
-      occupiedIndices.push_back(i);
+      baseIndex = i;
       break;
     }
   }
 
-  if (occupiedIndices.empty()) {
-    return moves;  // No occupied stones, should not happen here
+  if (baseIndex == -1) {
+    return moves;
   }
 
-  // Randomly select one occupied stone
-  int randIndex = rand() % occupiedIndices.size();
-  int baseIndex = occupiedIndices[randIndex];
-  int baseX = baseIndex % BOARD_WIDTH;
-  int baseY = baseIndex / BOARD_WIDTH;
+  // 2. Define offsets for 8 directions
+  // BOARD_WIDTH = 32
+  // 上(-32), 下(+32), 左(-1), 右(+1), および斜め
+  static const int offsets[8] = {
+      -BOARD_WIDTH - 1,
+      -BOARD_WIDTH,
+      -BOARD_WIDTH + 1,  // Upper-Left, Up, Upper-Right
+      -1,
+      1,  // Left, Right
+      BOARD_WIDTH - 1,
+      BOARD_WIDTH,
+      BOARD_WIDTH + 1  // Lower-Left, Down, Lower-Right
+  };
 
-  // Check neighboring cells (8 directions)
-  std::vector<std::pair<int, int>> directions = {{-1, -1}, {0, -1}, {1, -1}, {-1, 0},
-                                                 {1, 0},   {-1, 1}, {0, 1},  {1, 1}};
+  // Base X coordinate for wrapping check (0-31)
+  int baseX = baseIndex & 31;  // equivalent to: baseIndex % 32
 
-  for (const auto& dir : directions) {
-    int nx = baseX + dir.first;
-    int ny = baseY + dir.second;
+  // 3. Randomize search start direction
+  // 元のコードは固定順序でしたが、AIの挙動としてランダムな方向から探す方が自然です
+  int startDir = rand() % 8;
 
-    if (nx >= 0 && nx < BOARD_SIZE && ny >= 0 && ny < BOARD_SIZE) {
-      int nIndex = ny * BOARD_WIDTH + nx;
-      if (!occupied.test(nIndex)) {
-        moves.push_back({nx, ny, 0});
-        return moves;  // Return immediately after finding the first valid neighbor
-      }
+  for (int k = 0; k < 8; ++k) {
+    // ランダムな位置から8方向を巡回
+    int dirIdx = (startDir + k) % 8;
+    int offset = offsets[dirIdx];
+
+    int nIndex = baseIndex + offset;
+
+    // [A] 配列の範囲チェック
+    if (nIndex < 0 || nIndex >= MAX_CELLS)
+      continue;
+
+    // [B] 横方向のラップアラウンド（折り返し）チェック
+    // 1次元配列上で単に -1 すると、行が変わって右端に行ってしまうのを防ぐ
+    int nX = nIndex & 31;  // nIndex % 32
+    if (std::abs(baseX - nX) > 1)
+      continue;
+
+    // [C] 盤面の有効範囲チェック
+    // パディング領域(x >= 19)への着手を禁止
+    if (nX >= BOARD_SIZE)
+      continue;
+
+    // [D] 空きマスかどうかチェック
+    if (!occupied.test(nIndex)) {
+      // 見つかったら即座に返す
+      moves.push_back({nIndex, 0});
+      return moves;
     }
   }
 
-  return moves;  // Fallback: no valid neighbors found
+  return moves;  // 周囲がすべて埋まっている場合
 }
 
 int AI::_getDepthFromLevel(AILevel level) {

--- a/src/AI.cpp
+++ b/src/AI.cpp
@@ -56,12 +56,12 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
     int beta = std::numeric_limits<int>::max();
 
     for (const Move& m : moves) {
-      if (!searchBoard.makeMove(m.index))
+      if (!searchBoard.makeMoveAI(m.index))
         continue;
 
       // Win check optimization
       if (searchBoard.checkWin()) {
-        searchBoard.undo();
+        searchBoard.undoAI();
         // Found a winning move at this depth.
         // Store and return immediately (no need to search deeper)
         _tt.store(rootHash, depth, ScoreConfig::WIN, TTFlag::EXACT, m);
@@ -73,7 +73,7 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
       // Search children with reduced depth
       int score = _minimax(searchBoard, depth - 1, alpha, beta, false, cancelFlag);
 
-      searchBoard.undo();
+      searchBoard.undoAI();
 
       // Update Best Move for this depth
       if (score > currentDepthBestMove.score) {
@@ -156,12 +156,12 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
     int maxEval = std::numeric_limits<int>::min();
 
     for (const Move& m : moves) {
-      if (!board.makeMove(m.index))
+      if (!board.makeMoveAI(m.index))
         continue;
 
       // 即時勝利判定
       if (board.checkWin()) {
-        board.undo();
+        board.undoAI();
         int winScore = ScoreConfig::WIN + depth;
         _tt.store(key, depth, winScore, TTFlag::EXACT, m);
         return winScore;
@@ -184,7 +184,7 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
         }
       }
 
-      board.undo();
+      board.undoAI();
       if (cancelFlag.load())
         return 0;
 
@@ -220,11 +220,11 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
     int minEval = std::numeric_limits<int>::max();
 
     for (const Move& m : moves) {
-      if (!board.makeMove(m.index))
+      if (!board.makeMoveAI(m.index))
         continue;
 
       if (board.checkWin()) {
-        board.undo();
+        board.undoAI();
         int loseScore = -(ScoreConfig::WIN + depth);
         _tt.store(key, depth, loseScore, TTFlag::EXACT, m);
         return loseScore;
@@ -246,7 +246,7 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
         }
       }
 
-      board.undo();
+      board.undoAI();
       if (cancelFlag.load())
         return 0;
 

--- a/src/AI.cpp
+++ b/src/AI.cpp
@@ -18,93 +18,84 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
   // Clone the board ONCE for the search process
   Board searchBoard = board;
 
-  // =========================================================
-  // Iterative Deepening (ID)
-  // Start from depth 2 and increase until targetDepth.
-  // This fills the TT with good moves, making deeper searches faster.
-  // =========================================================
-  // --- 1. Move Generation & Ordering ---
-  // TT will now provide the "Best Move" from the previous depth (depth-1)
-  // to sort moves efficiently.
-  std::vector<Move> moves = _generateMoves(searchBoard, targetDepth, MAX_CELLS);
+  for (int depth = 2; depth <= targetDepth; ++depth) {
+    // --- 1. Move Generation & Ordering ---
+    std::vector<Move> moves = _generateMoves(searchBoard, depth, MAX_CELLS);
 
-  if (moves.empty())
-    return {-1, 0};
-  if (moves.size() == 1)
-    return moves[0];  // Optimization
+    if (moves.empty())
+      return {-1, 0};
+    if (moves.size() == 1)
+      return moves[0];  // Optimization
 
-  // Hash Move Check (Check TT for the root position)
-  uint64_t rootHash = searchBoard.getHash();
-  TTEntry* entry = _tt.get(rootHash);
+    // Hash Move Check (Check TT for the root position)
+    uint64_t rootHash = searchBoard.getHash();
+    TTEntry* entry = _tt.get(rootHash);
 
-  if (entry != nullptr && entry->bestMove.index != -1) {
-    // Move the best move from previous depth to the front
-    for (size_t i = 0; i < moves.size(); ++i) {
-      if (moves[i].index == entry->bestMove.index) {
-        std::swap(moves[0], moves[i]);
-        break;
+    if (entry != nullptr && entry->bestMove.index != -1) {
+      // Move the best move from previous depth to the front
+      for (size_t i = 0; i < moves.size(); ++i) {
+        if (moves[i].index == entry->bestMove.index) {
+          std::swap(moves[0], moves[i]);
+          break;
+        }
       }
     }
-  }
 
-  // --- 2. Root Search Loop ---
-  Move currentDepthBestMove = moves[0];
-  currentDepthBestMove.score = std::numeric_limits<int>::min();
+    // --- 2. Root Search Loop ---
+    Move currentDepthBestMove = moves[0];
+    currentDepthBestMove.score = std::numeric_limits<int>::min();
 
-  int alpha = std::numeric_limits<int>::min();
-  int beta = std::numeric_limits<int>::max();
+    int alpha = std::numeric_limits<int>::min();
+    int beta = std::numeric_limits<int>::max();
 
-  for (size_t i = 0; i < moves.size(); ++i) {
-    Move& m = moves[i];  // indexが必要なのでイテレータではなくインデックスアクセス推奨
-    if (!searchBoard.makeMoveAI(m.index))
-      continue;
+    for (size_t i = 0; i < moves.size(); ++i) {
+      Move& m = moves[i];
+      if (!searchBoard.makeMoveAI(m.index))
+        continue;
 
-    // Win check optimization
-    if (searchBoard.checkWin()) {
+      // Win check optimization
+      if (searchBoard.checkWin()) {
+        searchBoard.undoAI();
+        _tt.store(rootHash, depth, ScoreConfig::WIN, TTFlag::EXACT, m);
+        return m;
+      }
+
+      searchBoard.changeTurn();
+
+      if (i >= MAX_MOVES_TO_CONSIDER) {
+        searchBoard.undoAI();
+        continue;
+      }
+
+      // Search children with reduced depth
+      int score = _minimax(searchBoard, depth - 1, alpha, beta, false, cancelFlag);
+
       searchBoard.undoAI();
-      // Found a winning move at this depth.
-      // Store and return immediately (no need to search deeper)
-      _tt.store(rootHash, targetDepth, ScoreConfig::WIN, TTFlag::EXACT, m);
-      return m;
+
+      // Update Best Move for this depth
+      if (score > currentDepthBestMove.score) {
+        currentDepthBestMove = m;
+        currentDepthBestMove.score = score;
+      }
+
+      // Alpha Update
+      if (currentDepthBestMove.score > alpha) {
+        alpha = currentDepthBestMove.score;
+      }
+
+      if (cancelFlag.load())
+        break;
     }
 
-    searchBoard.changeTurn();
+    // --- 3. Update Global Best & Store to TT ---
+    globalBestMove = currentDepthBestMove;
 
-    if (i >= MAX_MOVES_TO_CONSIDER) {
-      searchBoard.undoAI();
-      continue;
-    }
+    TTFlag flag = TTFlag::EXACT;
+    _tt.store(rootHash, depth, globalBestMove.score, flag, globalBestMove);
 
-    // Search children with reduced depth
-    int score = _minimax(searchBoard, targetDepth - 1, alpha, beta, false, cancelFlag);
-
-    searchBoard.undoAI();
-
-    // Update Best Move for this depth
-    if (score > currentDepthBestMove.score) {
-      currentDepthBestMove = m;
-      currentDepthBestMove.score = score;
-    }
-
-    // Alpha Update
-    if (currentDepthBestMove.score > alpha) {
-      alpha = currentDepthBestMove.score;
-    }
-
-    // Win Threshold Break
-    if (alpha >= ScoreConfig::WIN - 1000) {
+    if (cancelFlag.load())
       break;
-    }
   }
-
-  // --- 3. Update Global Best & Store to TT ---
-  globalBestMove = currentDepthBestMove;
-
-  // ★ CRITICAL: Store the Root Node result to TT
-  // This allows the next iteration (depth+1) to use this result for sorting,
-  // AND allows printPV to find the start of the chain.
-  TTFlag flag = TTFlag::EXACT;  // Root node is usually exact unless alpha/beta cut logic is complex
-  _tt.store(rootHash, 0, globalBestMove.score, flag, globalBestMove);
 
   return globalBestMove;
 }

--- a/src/AI.cpp
+++ b/src/AI.cpp
@@ -23,85 +23,88 @@ Move AI::getBestMove(const Board& board, Color color, AILevel level,
   // Start from depth 2 and increase until targetDepth.
   // This fills the TT with good moves, making deeper searches faster.
   // =========================================================
-  for (int depth = 2; depth <= targetDepth; ++depth) {
-    // --- 1. Move Generation & Ordering ---
-    // TT will now provide the "Best Move" from the previous depth (depth-1)
-    // to sort moves efficiently.
-    std::vector<Move> moves = _generateMoves(searchBoard, depth);
+  // --- 1. Move Generation & Ordering ---
+  // TT will now provide the "Best Move" from the previous depth (depth-1)
+  // to sort moves efficiently.
+  std::vector<Move> moves = _generateMoves(searchBoard, targetDepth, MAX_CELLS);
 
-    if (moves.empty())
-      return {-1, 0};
-    if (moves.size() == 1)
-      return moves[0];  // Optimization
+  if (moves.empty())
+    return {-1, 0};
+  if (moves.size() == 1)
+    return moves[0];  // Optimization
 
-    // Hash Move Check (Check TT for the root position)
-    uint64_t rootHash = searchBoard.getHash();
-    TTEntry* entry = _tt.get(rootHash);
+  // Hash Move Check (Check TT for the root position)
+  uint64_t rootHash = searchBoard.getHash();
+  TTEntry* entry = _tt.get(rootHash);
 
-    if (entry != nullptr && entry->bestMove.index != -1) {
-      // Move the best move from previous depth to the front
-      for (size_t i = 0; i < moves.size(); ++i) {
-        if (moves[i].index == entry->bestMove.index) {
-          std::swap(moves[0], moves[i]);
-          break;
-        }
-      }
-    }
-
-    // --- 2. Root Search Loop ---
-    Move currentDepthBestMove = moves[0];
-    currentDepthBestMove.score = std::numeric_limits<int>::min();
-
-    int alpha = std::numeric_limits<int>::min();
-    int beta = std::numeric_limits<int>::max();
-
-    for (const Move& m : moves) {
-      if (!searchBoard.makeMoveAI(m.index))
-        continue;
-
-      // Win check optimization
-      if (searchBoard.checkWin()) {
-        searchBoard.undoAI();
-        // Found a winning move at this depth.
-        // Store and return immediately (no need to search deeper)
-        _tt.store(rootHash, depth, ScoreConfig::WIN, TTFlag::EXACT, m);
-        return m;
-      }
-
-      searchBoard.changeTurn();
-
-      // Search children with reduced depth
-      int score = _minimax(searchBoard, depth - 1, alpha, beta, false, cancelFlag);
-
-      searchBoard.undoAI();
-
-      // Update Best Move for this depth
-      if (score > currentDepthBestMove.score) {
-        currentDepthBestMove = m;
-        currentDepthBestMove.score = score;
-      }
-
-      // Alpha Update
-      if (currentDepthBestMove.score > alpha) {
-        alpha = currentDepthBestMove.score;
-      }
-
-      // Win Threshold Break
-      if (alpha >= ScoreConfig::WIN - 1000) {
+  if (entry != nullptr && entry->bestMove.index != -1) {
+    // Move the best move from previous depth to the front
+    for (size_t i = 0; i < moves.size(); ++i) {
+      if (moves[i].index == entry->bestMove.index) {
+        std::swap(moves[0], moves[i]);
         break;
       }
     }
-
-    // --- 3. Update Global Best & Store to TT ---
-    globalBestMove = currentDepthBestMove;
-
-    // ★ CRITICAL: Store the Root Node result to TT
-    // This allows the next iteration (depth+1) to use this result for sorting,
-    // AND allows printPV to find the start of the chain.
-    TTFlag flag =
-        TTFlag::EXACT;  // Root node is usually exact unless alpha/beta cut logic is complex
-    _tt.store(rootHash, depth, globalBestMove.score, flag, globalBestMove);
   }
+
+  // --- 2. Root Search Loop ---
+  Move currentDepthBestMove = moves[0];
+  currentDepthBestMove.score = std::numeric_limits<int>::min();
+
+  int alpha = std::numeric_limits<int>::min();
+  int beta = std::numeric_limits<int>::max();
+
+  for (size_t i = 0; i < moves.size(); ++i) {
+    Move& m = moves[i];  // indexが必要なのでイテレータではなくインデックスアクセス推奨
+    if (!searchBoard.makeMoveAI(m.index))
+      continue;
+
+    // Win check optimization
+    if (searchBoard.checkWin()) {
+      searchBoard.undoAI();
+      // Found a winning move at this depth.
+      // Store and return immediately (no need to search deeper)
+      _tt.store(rootHash, targetDepth, ScoreConfig::WIN, TTFlag::EXACT, m);
+      return m;
+    }
+
+    searchBoard.changeTurn();
+
+    if (i >= MAX_MOVES_TO_CONSIDER) {
+      searchBoard.undoAI();
+      continue;
+    }
+
+    // Search children with reduced depth
+    int score = _minimax(searchBoard, targetDepth - 1, alpha, beta, false, cancelFlag);
+
+    searchBoard.undoAI();
+
+    // Update Best Move for this depth
+    if (score > currentDepthBestMove.score) {
+      currentDepthBestMove = m;
+      currentDepthBestMove.score = score;
+    }
+
+    // Alpha Update
+    if (currentDepthBestMove.score > alpha) {
+      alpha = currentDepthBestMove.score;
+    }
+
+    // Win Threshold Break
+    if (alpha >= ScoreConfig::WIN - 1000) {
+      break;
+    }
+  }
+
+  // --- 3. Update Global Best & Store to TT ---
+  globalBestMove = currentDepthBestMove;
+
+  // ★ CRITICAL: Store the Root Node result to TT
+  // This allows the next iteration (depth+1) to use this result for sorting,
+  // AND allows printPV to find the start of the chain.
+  TTFlag flag = TTFlag::EXACT;  // Root node is usually exact unless alpha/beta cut logic is complex
+  _tt.store(rootHash, 0, globalBestMove.score, flag, globalBestMove);
 
   return globalBestMove;
 }
@@ -131,7 +134,7 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
     return Evaluator::evaluate(board, _aiPlayer);
 
   // [3] Move Generation
-  std::vector<Move> moves = _generateMoves(board, depth);
+  std::vector<Move> moves = _generateMoves(board, depth, SEARCH_WIDTH);
   if (moves.empty())
     return 0;
 
@@ -279,9 +282,9 @@ int AI::_minimax(Board& board, int depth, int alpha, int beta, bool maximizingPl
   }
 }
 
-std::vector<Move> AI::_generateMoves(const Board& board, int depth) {
+std::vector<Move> AI::_generateMoves(const Board& board, int depth, size_t limit) {
   std::vector<Move> moves;
-  moves.reserve(64);  // Reserve memory to prevent reallocations
+  moves.reserve(128);
 
   BoardType occupied = board.getOccupiedStones();
 
@@ -351,8 +354,8 @@ std::vector<Move> AI::_generateMoves(const Board& board, int depth) {
   // If the opponent has a threat at the 11th best move, you will lose instantly.
   // Consider increasing this to 20-30 or using a dynamic threshold
   // (e.g., keep all moves within 500 points of the best move).
-  if (moves.size() > MAX_MOVES_TO_CONSIDER) {
-    moves.resize(MAX_MOVES_TO_CONSIDER);
+  if (moves.size() > limit) {
+    moves.resize(limit);
   }
 
   return moves;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -24,6 +24,7 @@ Board::Board()
 
   this->_colorToPlayer.clear();
   this->_history.clear();
+  this->_aiHistory.reserve(100);
 }
 
 void Board::setupPlayers(TurnOrder order) {
@@ -59,12 +60,51 @@ bool Board::makeMove(int index) {
   // Update hash
   this->_currentHash ^= Zobrist::getPieceHash(index, this->_currentTurn);
 
-  _processCapture(index);
+  _processCapture(index, nullptr);
 
   if (!this->_capturedStatus) {
     _DoubleThree(index);
     if (this->_doubleThreeStatus) {
       undo();
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool Board::makeMoveAI(int index) {
+  if (index < 0 || index >= MAX_CELLS || this->_sentinelStones.test(index))
+    return false;
+
+  if (this->_blackStones.test(index) || this->_whiteStones.test(index))
+    return false;
+
+  // create record for undo
+  AIMoveRecord record;
+  record.moveIndex = index;
+  record.prevHash = this->_currentHash;
+  record.prevBlackCaptures = this->_blackCaptures;
+  record.prevWhiteCaptures = this->_whiteCaptures;
+  record.capturedCount = 0;
+
+  this->_aiHistory.push_back(record);
+
+  if (this->_currentTurn == Color::BLACK) {
+    this->_blackStones.set(index);
+  } else {
+    this->_whiteStones.set(index);
+  }
+
+  // Update hash
+  this->_currentHash ^= Zobrist::getPieceHash(index, this->_currentTurn);
+
+  _processCapture(index, &record);
+
+  if (!this->_capturedStatus) {
+    _DoubleThree(index);
+    if (this->_doubleThreeStatus) {
+      undoAI();
       return false;
     }
   }
@@ -84,6 +124,36 @@ bool Board::undo() {
   this->_history.pop_back();
   _applyState(s);
   return true;
+}
+
+void Board::undoAI() {
+  if (this->_aiHistory.empty())
+    return;
+
+  AIMoveRecord record = this->_aiHistory.back();
+  this->_aiHistory.pop_back();
+
+  Color prevTurn = (this->_currentTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
+  this->_currentTurn = prevTurn;
+
+  if (prevTurn == Color::BLACK) {
+    this->_blackStones.reset(record.moveIndex);
+  } else {
+    this->_whiteStones.reset(record.moveIndex);
+  }
+
+  Color oppColor = (prevTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
+  BoardType* oppBoard = (oppColor == Color::BLACK) ? &this->_blackStones : &this->_whiteStones;
+
+  for (int i = 0; i < record.capturedCount; ++i) {
+    int capIndex = record.capturedIndices[i];
+    oppBoard->set(capIndex);
+  }
+
+  // 5. カウンターとハッシュを復元
+  this->_blackCaptures = record.prevBlackCaptures;
+  this->_whiteCaptures = record.prevWhiteCaptures;
+  this->_currentHash = record.prevHash;
 }
 
 void Board::saveState() {
@@ -300,7 +370,7 @@ int8_t Board::_getCaptureCount(Color color) const {
 
 // -- Rule Implementations --
 
-void Board::_processCapture(int index) {
+void Board::_processCapture(int index, AIMoveRecord* record) {
   BoardType& myStones = (this->_currentTurn == Color::BLACK) ? _blackStones : _whiteStones;
   BoardType& oppStones = (this->_currentTurn == Color::BLACK) ? _whiteStones : _blackStones;
   int8_t& myScore = (_currentTurn == Color::BLACK) ? _blackCaptures : _whiteCaptures;
@@ -328,6 +398,13 @@ void Board::_processCapture(int index) {
         myScore += 2;
 
         this->_capturedStatus = true;
+
+        if (record) {
+          if (record->capturedCount + 2 <= 8) {
+            record->capturedIndices[record->capturedCount++] = p1;
+            record->capturedIndices[record->capturedCount++] = p2;
+          }
+        }
       }
     }
   }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -5,15 +5,24 @@
 // ----------------------------------------------------------------
 
 Board::Board()
-    : _blackStones(0),
-      _whiteStones(0),
-      _currentTurn(Color::BLACK),
+    : _currentTurn(Color::BLACK),
       _nextTurn(Color::WHITE),
       _blackCaptures(0),
       _whiteCaptures(0),
       _capturedStatus(false),
       _doubleThreeStatus(false),
       _currentHash(0) {
+  this->_blackStones.reset();
+  this->_whiteStones.reset();
+
+  this->_sentinelStones.reset();
+  for (int y = 0; y < BOARD_SIZE; ++y) {
+    for (int x = BOARD_SIZE; x < BOARD_WIDTH; ++x) {
+      int index = y * BOARD_WIDTH + x;
+      _sentinelStones.set(index);
+    }
+  }
+
   this->_colorToPlayer.clear();
   this->_history.clear();
 }

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -24,6 +24,7 @@ Board::Board()
 
   this->_colorToPlayer.clear();
   this->_history.clear();
+  this->_aiHistory.clear();
   this->_aiHistory.reserve(100);
 }
 
@@ -84,11 +85,10 @@ bool Board::makeMoveAI(int index) {
   AIMoveRecord record;
   record.moveIndex = index;
   record.prevHash = this->_currentHash;
+  record.currentTurn = this->_currentTurn;
   record.prevBlackCaptures = this->_blackCaptures;
   record.prevWhiteCaptures = this->_whiteCaptures;
   record.capturedCount = 0;
-
-  this->_aiHistory.push_back(record);
 
   if (this->_currentTurn == Color::BLACK) {
     this->_blackStones.set(index);
@@ -100,6 +100,8 @@ bool Board::makeMoveAI(int index) {
   this->_currentHash ^= Zobrist::getPieceHash(index, this->_currentTurn);
 
   _processCapture(index, &record);
+
+  this->_aiHistory.push_back(record);
 
   if (!this->_capturedStatus) {
     _DoubleThree(index);
@@ -133,16 +135,15 @@ void Board::undoAI() {
   AIMoveRecord record = this->_aiHistory.back();
   this->_aiHistory.pop_back();
 
-  Color prevTurn = (this->_currentTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
-  this->_currentTurn = prevTurn;
+  this->_currentTurn = record.currentTurn;
 
-  if (prevTurn == Color::BLACK) {
+  if (record.currentTurn == Color::BLACK) {
     this->_blackStones.reset(record.moveIndex);
   } else {
     this->_whiteStones.reset(record.moveIndex);
   }
 
-  Color oppColor = (prevTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
+  Color oppColor = (record.currentTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
   BoardType* oppBoard = (oppColor == Color::BLACK) ? &this->_blackStones : &this->_whiteStones;
 
   for (int i = 0; i < record.capturedCount; ++i) {

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,7 +1,5 @@
 #include "Board.hpp"
 
-#include <iostream>  // TODO: デバッグ用
-
 // ----------------------------------------------------------------
 // Lifecycle & Setup
 // ----------------------------------------------------------------
@@ -10,6 +8,7 @@ Board::Board()
     : _blackStones(0),
       _whiteStones(0),
       _currentTurn(Color::BLACK),
+      _nextTurn(Color::WHITE),
       _blackCaptures(0),
       _whiteCaptures(0),
       _capturedStatus(false),
@@ -68,7 +67,9 @@ bool Board::makeMove(int x, int y) {
 }
 
 void Board::changeTurn() {
-  this->_currentTurn = (this->_currentTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
+  Color tmp = this->_nextTurn;
+  this->_nextTurn = this->_currentTurn;
+  this->_currentTurn = tmp;
   _currentHash ^= Zobrist::getBlackTurnHash();
 }
 
@@ -83,7 +84,8 @@ bool Board::undo() {
 
 void Board::saveState() {
   this->_history.push_back({this->_blackStones, this->_whiteStones, this->_blackCaptures,
-                            this->_whiteCaptures, this->_currentTurn, this->_currentHash});
+                            this->_whiteCaptures, this->_currentTurn, this->_nextTurn,
+                            this->_currentHash});
 }
 
 // ----------------------------------------------------------------

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -6,7 +6,6 @@
 
 Board::Board()
     : _currentTurn(Color::BLACK),
-      _nextTurn(Color::WHITE),
       _blackCaptures(0),
       _whiteCaptures(0),
       _capturedStatus(false),
@@ -42,11 +41,9 @@ void Board::setupPlayers(TurnOrder order) {
 // Core Gameplay Logic (Mutators)
 // ----------------------------------------------------------------
 
-bool Board::makeMove(int x, int y) {
-  if (x < 0 || x >= BOARD_SIZE || y < 0 || y >= BOARD_SIZE)
+bool Board::makeMove(int index) {
+  if (index < 0 || index >= MAX_CELLS || this->_sentinelStones.test(index))
     return false;
-
-  int index = _getIndex(x, y);
 
   if (this->_blackStones.test(index) || this->_whiteStones.test(index))
     return false;
@@ -65,7 +62,7 @@ bool Board::makeMove(int x, int y) {
   _processCapture(index);
 
   if (!this->_capturedStatus) {
-    _DoubleThree(x, y);
+    _DoubleThree(index);
     if (this->_doubleThreeStatus) {
       undo();
       return false;
@@ -76,10 +73,8 @@ bool Board::makeMove(int x, int y) {
 }
 
 void Board::changeTurn() {
-  Color tmp = this->_nextTurn;
-  this->_nextTurn = this->_currentTurn;
-  this->_currentTurn = tmp;
-  _currentHash ^= Zobrist::getBlackTurnHash();
+  _currentTurn = static_cast<Color>(3 ^ static_cast<int>(_currentTurn));
+  this->_currentHash ^= Zobrist::getBlackTurnHash();
 }
 
 bool Board::undo() {
@@ -93,8 +88,7 @@ bool Board::undo() {
 
 void Board::saveState() {
   this->_history.push_back({this->_blackStones, this->_whiteStones, this->_blackCaptures,
-                            this->_whiteCaptures, this->_currentTurn, this->_nextTurn,
-                            this->_currentHash});
+                            this->_whiteCaptures, this->_currentTurn, this->_currentHash});
 }
 
 // ----------------------------------------------------------------
@@ -114,7 +108,7 @@ bool Board::checkWin(Color color) const {
   const BoardType& myStones = getMyStones(color);
   const BoardType& oppStones = getOppStones(color);
 
-  for (int shift : ALL_SHIFTS) {
+  for (int shift : DIR_OFFSETS) {
     // Get the starting bitset for 5-in-a-row
     BoardType lines = _getFiveInARowBits(myStones, shift);
 
@@ -143,7 +137,7 @@ bool Board::checkWin(Color color) const {
 // -- Board Information --
 
 Color Board::getColorAt(int x, int y) const {
-  int index = _getIndex(x, y);
+  int index = getIndex(x, y);
   if (this->_blackStones.test(index))
     return Color::BLACK;
   if (this->_whiteStones.test(index))
@@ -152,7 +146,7 @@ Color Board::getColorAt(int x, int y) const {
 }
 
 Player Board::getPlayerAt(int x, int y) const {
-  int index = _getIndex(x, y);
+  int index = getIndex(x, y);
   std::map<Color, Player>::const_iterator it = this->_colorToPlayer.end();
   if (this->_blackStones.test(index))
     it = this->_colorToPlayer.find(Color::BLACK);
@@ -182,6 +176,10 @@ const BoardType& Board::getOppStones(Color myColor) const {
   return (myColor == Color::BLACK) ? _whiteStones : _blackStones;
 }
 
+const BoardType& Board::getSentinelStones() const {
+  return this->_sentinelStones;
+}
+
 // -- Computed Bitsets --
 
 // 有効な盤面範囲（壁以外）を表すマスクを定義
@@ -208,6 +206,10 @@ BoardType Board::getOccupiedStones() const {
 
 Color Board::getCurrentTurn() const {
   return this->_currentTurn;
+}
+
+Color Board::getNextTurn() const {
+  return static_cast<Color>(3 ^ static_cast<int>(_currentTurn));
 }
 
 Player Board::getCurrentPlayer() const {
@@ -263,6 +265,18 @@ BoardType Board::getCapturableStones(Color myColor) const {
   return capturable;
 }
 
+// -- Helpers --
+
+int Board::getIndex(int x, int y) const {
+  return y * BOARD_WIDTH + x;
+}
+
+std::pair<int, int> Board::getCoordinates(int index) const {
+  int y = index / BOARD_WIDTH;
+  int x = index % BOARD_WIDTH;
+  return {x, y};
+}
+
 // ----------------------------------------------------------------
 // Internal Helper Methods
 // ----------------------------------------------------------------
@@ -280,10 +294,6 @@ void Board::_applyState(const BoardState& state) {
 
 // -- Coordinate / Bit Utils --
 
-int Board::_getIndex(int x, int y) const {
-  return y * BOARD_WIDTH + x;
-}
-
 int8_t Board::_getCaptureCount(Color color) const {
   return (color == Color::BLACK) ? this->_blackCaptures : this->_whiteCaptures;
 }
@@ -297,7 +307,7 @@ void Board::_processCapture(int index) {
   Color oppColor = (this->_currentTurn == Color::BLACK) ? Color::WHITE : Color::BLACK;
   this->_capturedStatus = false;
 
-  for (int d : ALL_SHIFTS) {
+  for (int d : DIR_OFFSETS) {
     const int directions[] = {d, -d};
 
     for (int dir : directions) {
@@ -323,28 +333,29 @@ void Board::_processCapture(int index) {
   }
 }
 
-void Board::_DoubleThree(int x, int y) {
+void Board::_DoubleThree(int index) {
   _doubleThreeStatus = false;
 
   const BoardType& myStones = getMyStones(_currentTurn);
   const BoardType& oppStones = getOppStones(_currentTurn);
   int freeThreeCount = 0;
 
-  for (const auto& dir : CHECK_DIRS) {
+  for (int offset : DIR_OFFSETS) {
     // 1. Extract Line Bits
-    LineBits line = _getLineBits(x, y, dir, myStones, oppStones);
+    LineBits line = _getLineBits(index, offset, myStones, oppStones);
 
     // 2. Check for Free Three pattern
     if (_checkFreeThree(line)) {
       freeThreeCount++;
       if (freeThreeCount >= 2) {
         _doubleThreeStatus = true;
+        return;
       }
     }
   }
 }
 
-LineBits Board::_getLineBits(int x, int y, const Direction dir, const BoardType& myStones,
+LineBits Board::_getLineBits(int centerIndex, int offset, const BoardType& myStones,
                              const BoardType& oppStones) const {
   LineBits line = {0, 0};
 
@@ -356,21 +367,20 @@ LineBits Board::_getLineBits(int x, int y, const Direction dir, const BoardType&
     if (i == 0)
       continue;
 
-    int nx = x + i * dir.dx;
-    int ny = y + i * dir.dy;
+    int targetIndex = centerIndex + (i * offset);
 
     // Treat out-of-bounds as "enemy stone (wall)"
-    if (nx < 0 || nx >= BOARD_SIZE || ny < 0 || ny >= BOARD_SIZE) {
+    if (targetIndex < 0 || targetIndex >= MAX_CELLS || _sentinelStones.test(targetIndex)) {
+      line.opp |= (1 << (i + 5));  // 壁は敵石扱い
+      continue;
+    }
+    if (myStones.test(targetIndex)) {
+      line.my |= (1 << (i + 5));
+    } else if (oppStones.test(targetIndex)) {
       line.opp |= (1 << (i + 5));
-    } else {
-      int idx = _getIndex(dir.dx, dir.dy);
-      if (myStones.test(idx)) {
-        line.my |= (1 << (i + 5));
-      } else if (oppStones.test(idx)) {
-        line.opp |= (1 << (i + 5));
-      }
     }
   }
+
   return line;
 }
 
@@ -423,7 +433,7 @@ bool Board::_isWinningLineSafe(int startIdx, int shift, const BoardType& myStone
 
 bool Board::_isStoneCapturable(int index, const BoardType& myStones,
                                const BoardType& oppStones) const {
-  for (int dir : ALL_SHIFTS) {
+  for (int dir : DIR_OFFSETS) {
     const int neighbors[] = {dir, -dir};
 
     for (int d : neighbors) {

--- a/src/Evaluator.cpp
+++ b/src/Evaluator.cpp
@@ -71,75 +71,73 @@ int Evaluator::evaluate(const Board& board, Color aiColor) {
   return static_cast<int>(myScore - weightedOppScore);
 }
 
-int Evaluator::evaluateMovePriority(const Board& board, int x, int y, Color myColor) {
+int Evaluator::evaluateMovePriority(const Board& board, int index, Color myColor) {
   int score = 0;
-  Color oppColor = (myColor == Color::BLACK) ? Color::WHITE : Color::BLACK;
 
   // 1. Centrality Bonus (Optional but recommended)
-  // Encourages play in the center early game.
+  int x = index & WIDTH_MASK;    // index % 32
+  int y = index >> WIDTH_SHIFT;  // index / 32
+
   int centerDist = std::abs(x - BOARD_SIZE / 2) + std::abs(y - BOARD_SIZE / 2);
-  score += (10 - centerDist);  // Small bonus (0-10 points)
+  score += (10 - centerDist);
 
-  // 2. Capture Heuristic (Crucial for Ninuki-Renju)
-  // If this move captures something, give it a HUGE bonus.
-  // It's worth checking even if slightly expensive because captures alter the board state
-  // significantly. (Assuming _CheckCapture is a lightweight helper you might add, or rely on line
-  // checks) For now, we stick to line checks as requested.
+  // 準備: bitsetへの参照をキャッシュして高速アクセス
+  const BoardType& myStones = board.getMyStones(myColor);
+  const BoardType& oppStones = board.getOppStones(myColor);
+  const BoardType& sentinels = board.getSentinelStones();
 
-  // 3. Line Analysis
-  // [1,0], [0,1], [1,1], [1,-1]
-  // Unrolling the loop manually for performance as you did is good.
-  score += _CheckLineScore(board, x, y, 1, 0, myColor, oppColor);
-  score += _CheckLineScore(board, x, y, 0, 1, myColor, oppColor);
-  score += _CheckLineScore(board, x, y, 1, 1, myColor, oppColor);
-  score += _CheckLineScore(board, x, y, 1, -1, myColor, oppColor);
+  // 2. Line Analysis with Offsets
+  // index操作だけで済むためループ展開がさらに効果的になります
+
+  // Horizontal (Offset 1)
+  score += _CheckLineScore(index, 1, myStones, oppStones, sentinels);
+  // Vertical (Offset 32)
+  score += _CheckLineScore(index, BOARD_WIDTH, myStones, oppStones, sentinels);
+  // Diagonal \ (Offset 33: 1 down + 1 right)
+  score += _CheckLineScore(index, BOARD_WIDTH + 1, myStones, oppStones, sentinels);
+  // Diagonal / (Offset 31: 1 down + 1 left)
+  score += _CheckLineScore(index, BOARD_WIDTH - 1, myStones, oppStones, sentinels);
 
   return score;
 }
 
-int Evaluator::_CheckLineScore(const Board& board, int x, int y, int dx, int dy, Color myColor,
-                               Color oppColor) {
-  int score = 0;
-
-  // We need to count consecutive stones in both directions
+int Evaluator::_CheckLineScore(int index, int offset, const BoardType& myStones,
+                               const BoardType& oppStones, const BoardType& sentinels) {
   // 0: My stones, 1: Opponent stones
   int consecutive[2] = {0, 0};
   int openEnds[2] = {0, 0};
 
-  // Helper lambda to scan a direction
-  auto scan = [&](int k_start, int k_end, int sign) {
+  // direction: 1 (Forward), -1 (Backward)
+  for (int sign = -1; sign <= 1; sign += 2) {
     bool myBlocked = false;
     bool oppBlocked = false;
 
-    for (int k = k_start; k <= k_end; ++k) {
-      int nx = x + (dx * k * sign);
-      int ny = y + (dy * k * sign);
+    for (int k = 1; k <= 4; ++k) {
+      int currentIdx = index + (offset * k * sign);
 
-      if (nx < 0 || nx >= BOARD_SIZE || ny < 0 || ny >= BOARD_SIZE) {
-        // Board edge counts as blocked
-        return;
-      }
-
-      Color c = board.getColorAt(nx, ny);
+      if (currentIdx < 0 || currentIdx >= MAX_CELLS || sentinels.test(currentIdx))
+        break;
 
       // --- Check My Stones ---
+      bool isMyStone = myStones.test(currentIdx);
+      bool isOppStone = oppStones.test(currentIdx);
+
       if (!myBlocked) {
-        if (c == myColor) {
+        if (isMyStone) {
           consecutive[0]++;
         } else {
-          if (c == Color::NONE)
+          if (!isOppStone)  // Empty
             openEnds[0]++;
-          myBlocked = true;  // Stop counting my consecutive
+          myBlocked = true;
         }
       }
 
       // --- Check Opponent Stones ---
-      // We are checking: "If I hadn't played here, how many would opp have?"
       if (!oppBlocked) {
-        if (c == oppColor) {
+        if (isOppStone) {
           consecutive[1]++;
         } else {
-          if (c == Color::NONE)
+          if (!isMyStone)  // Empty
             openEnds[1]++;
           oppBlocked = true;
         }
@@ -148,45 +146,37 @@ int Evaluator::_CheckLineScore(const Board& board, int x, int y, int dx, int dy,
       if (myBlocked && oppBlocked)
         break;
     }
-  };
+  }
 
-  // Scan Forward and Backward
-  scan(1, 4, 1);   // Forward (Limit 4 is enough to detect 5)
-  scan(1, 4, -1);  // Backward
+  // --- Scoring Logic (変更なし) ---
+  int score = 0;
 
-  // --- Scoring Logic ---
-
-  // 1. My Offense (Trying to build lines)
-  // +1 because we are placing a stone at (x,y)
+  // 1. My Offense
   int myTotal = consecutive[0] + 1;
-
-  if (myTotal >= 5) {
-    score += ScoreConfig::PRIORITY_WIN;  // 5連
-  } else if (myTotal == 4) {
+  if (myTotal >= 5)
+    score += ScoreConfig::PRIORITY_WIN;  // XXXXX
+  else if (myTotal == 4) {
     if (openEnds[0] >= 2)
       score += ScoreConfig::PRIORITY_OPEN_FOUR;  // .XXXX.
     else if (openEnds[0] >= 1)
-      score += ScoreConfig::PRIORITY_OPEN_THREE;  // Closed 4 (still strong)
+      score += ScoreConfig::PRIORITY_OPEN_THREE;  // XXXX.
   } else if (myTotal == 3) {
     if (openEnds[0] >= 2)
       score += ScoreConfig::PRIORITY_OPEN_THREE;  // .XXX.
   }
 
-  // 2. Opponent Defense (Blocking their lines)
-  // +1 because if we don't play here, they will play here and connect their lines
+  // 2. Opponent Defense
   int oppTotal = consecutive[1] + 1;
-
-  if (oppTotal >= 5) {
-    score += ScoreConfig::PRIORITY_BLOCK_WIN;  // Block their 5
-  } else if (oppTotal == 4) {
-    // Blocking a 4 is critical. Even a closed 4 is deadly if not blocked.
+  if (oppTotal >= 5)
+    score += ScoreConfig::PRIORITY_BLOCK_WIN;  // XXXXX
+  else if (oppTotal == 4) {
     if (openEnds[1] >= 2)
-      score += ScoreConfig::PRIORITY_BLOCK_OPEN_4;  // Block .XXXX.
+      score += ScoreConfig::PRIORITY_BLOCK_OPEN_4;  // .XXXX.
     else if (openEnds[1] >= 1)
-      score += ScoreConfig::PRIORITY_BLOCK_OPEN_4;  // Block X.XXX (Force block)
+      score += ScoreConfig::PRIORITY_BLOCK_OPEN_4;  // XXXX. (Force block)
   } else if (oppTotal == 3) {
     if (openEnds[1] >= 2)
-      score += ScoreConfig::PRIORITY_BLOCK_OPEN_3;  // Block .XXX.
+      score += ScoreConfig::PRIORITY_BLOCK_OPEN_3;  // .XXX.
   }
 
   return score;

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -89,7 +89,9 @@ void GameScene::handleClick(int x, int y) {
     // makeMoveが成功（ルール上OK）なら、内部状態が更新される
     float posX = this->_boardOffset.x + static_cast<float>(col * this->_cellSize);
     float posY = this->_boardOffset.y + static_cast<float>(row * this->_cellSize);
-    if (this->_board.makeMove(col, row)) {
+    int index = this->_board.getIndex(col, row);
+
+    if (this->_board.makeMove(index)) {
       _cancelHint();
 
       if (this->_board.getCapturedStatus()) {
@@ -182,10 +184,11 @@ void GameScene::update(float df) {
 }
 
 void GameScene::_applyAIMove(Move move) {
-  this->_board.makeMove(move.x, move.y);
+  this->_board.makeMove(move.index);
 
-  float posX = this->_boardOffset.x + static_cast<float>(move.x * this->_cellSize);
-  float posY = this->_boardOffset.y + static_cast<float>(move.y * this->_cellSize);
+  std::pair<int, int> pair = this->_board.getCoordinates(move.index);
+  float posX = this->_boardOffset.x + static_cast<float>(pair.first * this->_cellSize);
+  float posY = this->_boardOffset.y + static_cast<float>(pair.second * this->_cellSize);
 
   if (this->_board.getCapturedStatus()) {
     displayTimedMessage("Capture", {posX, posY});
@@ -359,7 +362,8 @@ void GameScene::_handleHint() {
 
     if (this->_hintFuture.wait_for(std::chrono::seconds(0)) == std::future_status::ready) {
       Move bestMove = this->_hintFuture.get();
-      this->_hintMove = {bestMove.x, bestMove.y};
+      std::pair<int, int> coords = this->_board.getCoordinates(bestMove.index);
+      this->_hintMove = {coords.first, coords.second};
 
       float finalTime = this->_aiClock.getElapsedTime().asSeconds();
       std::stringstream ssFinal;

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -303,16 +303,12 @@ void GameScene::_onAIAssist() {
   this->_isCalculatingHint = true;
   this->_hintMove = {-1, -1};
 
-  AI ai;
-  const Board& board = this->_board;
-  Color turn = this->_board.getCurrentTurn();
-  AILevel level = AILevel::Hard;
-
   std::shared_ptr<std::atomic<bool>> flagPtr = _cancelFlag;
   this->_aiClock.restart();
 
-  this->_hintFuture = std::async(std::launch::async, [ai, board, turn, level, flagPtr]() mutable {
-    return ai.getBestMove(board, turn, level, *flagPtr);
+  this->_hintFuture = std::async(std::launch::async, [this, flagPtr]() mutable {
+    return this->_ai.getBestMove(this->_board, this->_board.getCurrentTurn(), AILevel::Hard,
+                                 *flagPtr);
   });
 }
 
@@ -387,16 +383,13 @@ void GameScene::_handleAIProcess(float df) {
         this->_cancelFlag = std::make_shared<std::atomic<bool>>(false);
         std::shared_ptr<std::atomic<bool>> flagPtr = _cancelFlag;
 
-        AI ai;
-        Board boardCopy = this->_board;
-        Color turn = this->_board.getCurrentTurn();
         AILevel level = this->_aiLevel;
 
         this->_aiClock.restart();
-        this->_aiFuture =
-            std::async(std::launch::async, [ai, boardCopy, turn, level, flagPtr]() mutable {
-              return ai.getBestMove(boardCopy, turn, level, *flagPtr);
-            });
+        this->_aiFuture = std::async(std::launch::async, [this, flagPtr]() mutable {
+          return this->_ai.getBestMove(this->_board, this->_board.getCurrentTurn(), this->_aiLevel,
+                                       *flagPtr);
+        });
       }
     } else {
       float elapsed = this->_aiClock.getElapsedTime().asSeconds();

--- a/src/TranspositionTable.cpp
+++ b/src/TranspositionTable.cpp
@@ -9,8 +9,8 @@ TranspositionTable::TranspositionTable(size_t sizeExp) {
 
 void TranspositionTable::clear() {
   // 空のエントリで埋める
-  // key=0, depth=-1, score=0, EXACT, {-1,-1}
-  std::fill(_table.begin(), _table.end(), TTEntry{0, 0, -1, TTFlag::EXACT, {-1, -1, 0}});
+  // key=0, depth=-1, score=0, EXACT, {-1,0}
+  std::fill(_table.begin(), _table.end(), TTEntry{0, 0, -1, TTFlag::EXACT, {-1, 0}});
 }
 
 TTEntry* TranspositionTable::get(uint64_t key) {

--- a/src/Zobrist.cpp
+++ b/src/Zobrist.cpp
@@ -1,0 +1,29 @@
+#include "Zobrist.hpp"
+
+// 静的メンバ変数の実体定義
+// ここでメモリが確保されます（初期値は0）
+uint64_t Zobrist::table[MAX_CELLS][2];
+uint64_t Zobrist::blackTurn;
+
+void Zobrist::initialize() {
+  // 固定シードを使用（再現性のため）
+  std::mt19937_64 rng(12345);
+  std::uniform_int_distribution<uint64_t> dist;
+
+  for (int i = 0; i < MAX_CELLS; ++i) {
+    table[i][0] = dist(rng);  // 黒用の乱数
+    table[i][1] = dist(rng);  // 白用の乱数
+  }
+  blackTurn = dist(rng);
+}
+
+uint64_t Zobrist::getPieceHash(int index, Color color) {
+  // color が BLACK なら 0, WHITE なら 1
+  // Color enumの実装に依存しますが、安全のため条件演算子を使用
+  int colorIndex = (color == Color::BLACK) ? 0 : 1;
+  return table[index][colorIndex];
+}
+
+uint64_t Zobrist::getBlackTurnHash() {
+  return blackTurn;
+}


### PR DESCRIPTION
# 概要
AIの思考ルーチンにおける主要なパフォーマンスボトルネックであった「盤面のコピー処理（`saveState`）」を解消し、探索速度を大幅に向上させました。 また、反復深化（Iterative Deepening）と段階的な枝刈り戦略（LMP）を導入することで、即時の勝利/敗北の見落としを防ぎつつ、有望な手をより深く探索できるようにロジックを最適化しました。

## 変更点

- **変更点1：AI用履歴処理の軽量化 (`makeMoveAI` / `undoAI`)**
    - 従来の手法：`BoardState` 構造体を用いて盤面全体（BitSet）をコピー・保存していたため、メモリ帯域と処理時間を圧迫していた。
    - **改善後**：差分情報（着手位置、直前のハッシュ、捕獲された石の位置）のみを記録する軽量構造体 `AIMoveRecord` を導入。
    - これにより、探索中の状態遷移コストを `O(N)` からほぼ `O(1)` に削減。
    - Zobrist Hash の更新も、盤面全体の再計算ではなくXOR演算による差分更新へ変更。

- **変更点2：探索戦略の最適化（反復深化と枝刈り）**
    - `getBestMove` に 反復深化 (Iterative Deepening) ループを実装。前回の深さの探索結果（置換表）を利用して並べ替えを行うことで、探索効率を向上。
    - Late Move Pruning (LMP) の導入：
        - ルート（深さ1）：全ての候補手に対して即時勝利判定 (`checkWin`) を実施し、取りこぼしを防ぐ。ただし、再帰的な探索（`_minimax`）を行うのは評価値の高い **上位14手** に限定。
        - それ以降（深さ2〜）：探索幅を上位3手に絞ることで、探索速度を維持。
        
- **変更点3：コードのリファクタリング**
    - `_processCapture` ロジックを共通化し、通常の手 (`makeMove`) とAI探索 (`makeMoveAI`) の両方で利用できるように修正。
    - `Board` クラスにAI探索専用の履歴スタック `_aiHistory` を追加（`reserve` により動的確保を回避）。
