### PR TITLE
feature: display forbidden hand

### DIFF
--- a/include/Board.hpp
+++ b/include/Board.hpp
@@ -148,6 +148,8 @@ class Board {
   bool getDoubleThreeStatus() const;
   void setDoubleThreeStatus(bool status);
   bool getCapturedStatus() const;
+  bool getForbiddenHandStatus() const;
+  void setForbiddenHandStatus(bool status);
 
   // -- Hashing --
   uint64_t getHash() const;
@@ -252,6 +254,7 @@ class Board {
   // Flags for the last move (for UI or logic checks)
   bool _capturedStatus;
   bool _doubleThreeStatus;
+  bool _forbiddenHandStatus;
 
   // Meta Data
   std::map<Color, Player> _colorToPlayer;

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -313,6 +313,14 @@ bool Board::getCapturedStatus() const {
   return this->_capturedStatus;
 }
 
+bool Board::getForbiddenHandStatus() const {
+  return this->_forbiddenHandStatus;
+}
+
+void Board::setForbiddenHandStatus(bool status) {
+  this->_forbiddenHandStatus = status;
+}
+
 // -- Hashing --
 uint64_t Board::getHash() const {
   return this->_currentHash;

--- a/src/GameScene.cpp
+++ b/src/GameScene.cpp
@@ -109,6 +109,9 @@ void GameScene::handleClick(int x, int y) {
     if (this->_board.getDoubleThreeStatus()) {
       displayTimedMessage("DoubleThree", {posX, posY});
       this->_board.setDoubleThreeStatus(false);
+    } else if (this->_board.getForbiddenHandStatus()) {
+      displayTimedMessage("Forbidden Hand", {posX, posY});
+      this->_board.setForbiddenHandStatus(false);
     }
   }
 }


### PR DESCRIPTION
# 概要
opening ruleの禁じ手をUIで表示するようにしました

## 変更点

- Board::_forbiddenHandStatusの追加
- Board::getForbiddenHandStatusとsetForbiddenHandStatusを追加
- 変更点3

## 影響範囲

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- 禁じ手の判定の処理は追加してないので今まで通りプレイできること


## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
