### PR TITLE
オープニングルールのルールの説明を表示

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ SRC_FILES          = main.cpp \
 					 Evaluator.cpp \
 					 TranspositionTable.cpp \
 					 Zobrist.cpp \
+					 Tooltip.cpp
 
 IFLAGS            += -Iinclude
 SRCS               = $(addprefix $(SRC_DIR), $(SRC_FILES))

--- a/include/MenuScene.hpp
+++ b/include/MenuScene.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include <Enums.hpp>
-#include <Scene.hpp>
-#include <Theme.hpp>
 #include <functional>
+
+#include "Enums.hpp"
+#include "Scene.hpp"
+#include "Theme.hpp"
+#include "Tooltip.hpp"
 
 class MenuScene : public Scene {
  public:
@@ -47,6 +49,8 @@ class MenuScene : public Scene {
   sf::Text _proText;
   sf::RectangleShape _longProButton;
   sf::Text _longProText;
+  Tooltip _tooltip;
+  void _checkHoverOnRules(sf::RenderWindow& window);
 
   void _updateButtonStatus(sf::RectangleShape& button, bool isActive);
 };

--- a/include/Theme.hpp
+++ b/include/Theme.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SFML/Graphics.hpp>
+#include "SFML/Graphics.hpp"
 
 namespace Theme {
 
@@ -19,6 +19,7 @@ const unsigned int Title = 80;
 const unsigned int Header = 45;
 const unsigned int Text = 35;
 const unsigned int Button = 25;
+const unsigned int Tooltip = 20;
 }  // namespace FontSize
 
 namespace Size {

--- a/include/Tooltip.hpp
+++ b/include/Tooltip.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "SFML/Graphics.hpp"
+
+class Tooltip {
+ public:
+  Tooltip(sf::Font& font);
+
+  void show(const std::string& str, sf::Vector2f mousePos, const sf::RenderWindow& window);
+
+  void hide();
+
+  void draw(sf::RenderWindow& window);
+
+ private:
+  sf::RectangleShape _background;
+  sf::Text _text;
+  bool _visible = false;
+};

--- a/src/Gomoku.cpp
+++ b/src/Gomoku.cpp
@@ -1,4 +1,4 @@
-#include <Gomoku.hpp>
+#include "Gomoku.hpp"
 
 Gomoku::Gomoku() : _window(sf::VideoMode({1080, 1000}), "Gomoku"), font() {
   _initFont("arial.ttf");

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -1,4 +1,4 @@
-#include <MenuScene.hpp>
+#include "MenuScene.hpp"
 
 MenuScene::MenuScene(sf::Font& font, const sf::Vector2u& initalSize)
     : _font(font),
@@ -14,7 +14,8 @@ MenuScene::MenuScene(sf::Font& font, const sf::Vector2u& initalSize)
       _openingRuleText(font, "Select starting condition."),
       _standardText(font, "Standard"),
       _proText(font, "Pro"),
-      _longProText(font, "Long Pro") {
+      _longProText(font, "Long Pro"),
+      _tooltip(font) {
   this->_titleText.setCharacterSize(Theme::FontSize::Title);
   this->_titleText.setFillColor(Theme::Color::Text);
   this->_titleText.setStyle(sf::Text::Bold);
@@ -170,6 +171,29 @@ void MenuScene::update(float dt) {
   _updateButtonStatus(this->_longProButton, this->_openingRule == OpeningRule::LongPro);
 }
 
+void MenuScene::_checkHoverOnRules(sf::RenderWindow& window) {
+  sf::Vector2i pixelPos = sf::Mouse::getPosition(window);
+  sf::Vector2f mousePos = window.mapPixelToCoords(pixelPos);
+  bool isHovering = false;
+
+  if (this->_standardButton.getGlobalBounds().contains(mousePos)) {
+    _tooltip.show("No restrictions.\nJust connect 5 stones.", mousePos, window);
+    isHovering = true;
+  } else if (this->_proButton.getGlobalBounds().contains(mousePos)) {
+    _tooltip.show("- First move must be center.\n- Third move must be outside 3x3 zone.", mousePos,
+                  window);
+    isHovering = true;
+  } else if (this->_longProButton.getGlobalBounds().contains(mousePos)) {
+    _tooltip.show("- First move must be center.\n- Third move must be outside 4x4 zone.", mousePos,
+                  window);
+    isHovering = true;
+  }
+
+  if (!isHovering) {
+    _tooltip.hide();
+  }
+}
+
 void MenuScene::_updateButtonStatus(sf::RectangleShape& button, bool isActive) {
   button.setFillColor(isActive ? Theme::Color::ButtonActive : Theme::Color::ButtonIdle);
 }
@@ -198,6 +222,8 @@ void MenuScene::render(sf::RenderWindow& window) {
   window.draw(this->_proText);
   window.draw(this->_longProButton);
   window.draw(this->_longProText);
+  _checkHoverOnRules(window);
+  _tooltip.draw(window);
 }
 
 void MenuScene::onResize(const sf::Vector2u& windowSize) {

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -177,7 +177,7 @@ void MenuScene::_checkHoverOnRules(sf::RenderWindow& window) {
   bool isHovering = false;
 
   if (this->_standardButton.getGlobalBounds().contains(mousePos)) {
-    _tooltip.show("No restrictions.\nJust connect 5 stones.", mousePos, window);
+    _tooltip.show("No restrictions.", mousePos, window);
     isHovering = true;
   } else if (this->_proButton.getGlobalBounds().contains(mousePos)) {
     _tooltip.show("- First move must be center.\n- Third move must be outside 3x3 zone.", mousePos,

--- a/src/Tooltip.cpp
+++ b/src/Tooltip.cpp
@@ -1,0 +1,51 @@
+#include "Tooltip.hpp"
+
+#include "Theme.hpp"
+
+Tooltip::Tooltip(sf::Font& font) : _text(font) {
+  this->_text.setCharacterSize(Theme::FontSize::Tooltip);
+  this->_text.setFillColor(Theme::Color::Text);
+
+  this->_background.setFillColor(Theme::Color::ButtonIdle);
+  this->_background.setOutlineColor(sf::Color::White);
+  this->_background.setOutlineThickness(1.f);
+}
+
+void Tooltip::hide() {
+  this->_visible = false;
+}
+
+void Tooltip::show(const std::string& str, sf::Vector2f mousePos, const sf::RenderWindow& window) {
+  this->_text.setString(str);
+  this->_visible = true;
+
+  sf::FloatRect textBounds = this->_text.getLocalBounds();
+  sf::Vector2f bgSize = {textBounds.size.x + 20.f, textBounds.size.y + 25.f};
+  this->_background.setSize(bgSize);
+
+  sf::Vector2f viewSize = window.getView().getSize();
+  sf::Vector2f viewCenter = window.getView().getCenter();
+  sf::Vector2f viewTopLeft = viewCenter - (viewSize / 2.f);
+
+  float offset = 15.f;
+  float finalX = mousePos.x + offset;
+  float finalY = mousePos.y + offset;
+
+  if (finalX + bgSize.x > viewTopLeft.x + viewSize.x) {
+    finalX = mousePos.x - offset - bgSize.x;
+  }
+
+  if (finalY + bgSize.y > viewTopLeft.y + viewSize.y) {
+    finalY = mousePos.y - offset - bgSize.y;
+  }
+
+  this->_background.setPosition({finalX, finalY});
+  this->_text.setPosition({finalX + 10.f, finalY + 10.f});
+}
+
+void Tooltip::draw(sf::RenderWindow& window) {
+  if (this->_visible) {
+    window.draw(this->_background);
+    window.draw(this->_text);
+  }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#include <Gomoku.hpp>
-#include <SFML/Graphics.hpp>
 #include <chrono>
 #include <cmath>
 #include <csignal>
@@ -7,6 +5,9 @@
 #include <optional>
 #include <string>
 #include <vector>
+
+#include "Gomoku.hpp"
+#include "SFML/Graphics.hpp"
 
 Gomoku* g_pointer = nullptr;
 


### PR DESCRIPTION
# 概要
MenuSceneでルールの上にマウスがある時にルールを表示しています。

## 変更点

- Tooltip.hpp, cppを追加
- MenuScene::render()にてマウスホバーを確認して表示


## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- メニュー画面で各ルールの上をマウスをホバーさせるとルールが表示される


## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
