### PR TITLE
cleanで.objを消去

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ $(OBJ_DIR)%.o: $(SRC_DIR)%.cpp | $(OBJ_DIR)
 	$(CXX) $(CXXFLAGS) $(IFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJS)
+	rm -rf $(OBJ_DIR)
 
 fclean: clean
 	rm -f $(NAME)


### PR DESCRIPTION
# 概要
Makefileでcleanのルールが.obj内のファイルを消すだけで.objを消してなかったので修正しました。

## 変更点

- Makefileのclean
- 変更点2
- 変更点3

## 影響範囲

このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。

## テスト

このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。

- テストケース1
- テストケース2
- テストケース3

## 関連Issue

このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。

- close #xxx
